### PR TITLE
escape Object other than String too

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
@@ -193,13 +193,7 @@ class Variable extends HelperResolver {
     if (value instanceof Handlebars.SafeString) {
       return false;
     }
-    boolean isString =
-        value instanceof CharSequence || value instanceof Character;
-    if (isString) {
-      return type == TagType.VAR;
-    } else {
-      return false;
-    }
+    return type == TagType.VAR;
   }
 
   @Override

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ToStringTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ToStringTest.java
@@ -1,0 +1,33 @@
+package com.github.jknack.handlebars;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ToStringTest {
+
+    public static class UnsafeString {
+        String underlying;
+
+        public UnsafeString(String underlying) {
+            this.underlying = underlying;
+        }
+
+        @Override
+        public String toString() {
+            return "<h1>" + underlying + "</h1>";
+        }
+    }
+
+    @Test
+    public void unsafeString() throws IOException {
+        Handlebars handlebars = new Handlebars();
+        Template template = handlebars.compileInline("{{this}}");
+
+        String result = template.apply(new UnsafeString("Hello"));
+
+        assertEquals("&lt;h1&gt;Hello&lt;/h1&gt;", result);
+    }
+}


### PR DESCRIPTION
Hello,

When a value which has toString() returns HTML unsafe characters is referenced, Handlebars.java does not escape it.

This is a pull request to solve that. I don't understand why Handlebars only escape CharSequence and Character, but the patch works fine in my environment and passed the testcases.

Regards,
Akira
