### PR TITLE
Bugfix for Handlebars Cache

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/cache/HighConcurrencyTemplateCache.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/cache/HighConcurrencyTemplateCache.java
@@ -154,7 +154,7 @@ public class HighConcurrencyTemplateCache implements TemplateCache {
           // fall through and retry
           interrupted = true;
         } catch (ExecutionException ex) {
-          if(future == null) cache.remove(source, futureTask);
+          if(future != null) cache.remove(source, future);
           throw launderThrowable(source, ex.getCause());
         }
       }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/cache/HighConcurrencyTemplateCacheTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/cache/HighConcurrencyTemplateCacheTest.java
@@ -150,10 +150,13 @@ public class HighConcurrencyTemplateCacheTest {
     expect(future.get()).andThrow(new ExecutionException(new IllegalArgumentException()));
 
     Capture<TemplateSource> keyGet = new Capture<TemplateSource>();
+    Capture<TemplateSource> keyRemove = new Capture<TemplateSource>();
 
     ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache =
         createMock(ConcurrentMap.class);
+
     expect(cache.get(capture(keyGet))).andReturn(future);
+    expect(cache.remove(capture(keyRemove), eq(future))).andReturn(true);
 
     Parser parser = createMock(Parser.class);
 
@@ -209,10 +212,12 @@ public class HighConcurrencyTemplateCacheTest {
     expect(future.get()).andThrow(new ExecutionException(new Exception()));
 
     Capture<TemplateSource> keyGet = new Capture<TemplateSource>();
+    Capture<TemplateSource> keyRemove = new Capture<TemplateSource>();
 
     ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache =
         createMock(ConcurrentMap.class);
     expect(cache.get(capture(keyGet))).andReturn(future);
+    expect(cache.remove(capture(keyRemove), eq(future))).andReturn(true);
 
     Parser parser = createMock(Parser.class);
 


### PR DESCRIPTION
We are seeing an issue where if a template has a exception, it gets stuck in the cache with it forever. The only way to fix it requires a server restart. The issue is simple, when a Handlebars exception happens, you need to evict it out of the cache rather than continue keeping it there.
