### PR TITLE
Add support for customize the locale resolver

### DIFF
--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -69,7 +69,7 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
    * The locale resolver. The default resolver is LocaleContextHolderResolver.
    */
   private LocaleResolver localeResolver = new LocaleContextHolderResolver();
-  
+
   /**
    * Fail on missing file. Default is: true.
    */
@@ -228,13 +228,13 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
     this.valueResolvers = notEmpty(valueResolvers,
         "At least one value-resolver must be present.");
   }
-  
+
   /**
    * Set the locale resolver.
    *
    * @param localeResolver The value locale resolver.
    */
-  public void setLocaleResolver(LocaleResolver localeResolver) {
+  public void setLocaleResolver(final LocaleResolver localeResolver) {
     this.localeResolver = notNull(localeResolver,
         "the locale-resolver must be present.");
   }

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -38,6 +38,8 @@ import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.ValueResolver;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import com.github.jknack.handlebars.io.URLTemplateLoader;
+import com.github.jknack.handlebars.springmvc.locale.LocaleContextHolderResolver;
+import com.github.jknack.handlebars.springmvc.locale.LocaleResolver;
 
 /**
  * A Handlebars {@link ViewResolver view resolver}.
@@ -63,6 +65,11 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
    */
   private ValueResolver[] valueResolvers = ValueResolver.VALUE_RESOLVERS;
 
+  /**
+   * The locale resolver. The default resolver is LocaleContextHolderResolver.
+   */
+  private LocaleResolver localeResolver = new LocaleContextHolderResolver();
+  
   /**
    * Fail on missing file. Default is: true.
    */
@@ -171,7 +178,7 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
 
     // Add a message source helper
     handlebars.registerHelper("message", new MessageSourceHelper(
-        getApplicationContext()));
+        getApplicationContext(), localeResolver));
   }
 
   /**
@@ -220,6 +227,16 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
   public void setValueResolvers(final ValueResolver... valueResolvers) {
     this.valueResolvers = notEmpty(valueResolvers,
         "At least one value-resolver must be present.");
+  }
+  
+  /**
+   * Set the locale resolver.
+   *
+   * @param localeResolver The value locale resolver.
+   */
+  public void setLocaleResolver(LocaleResolver localeResolver) {
+    this.localeResolver = notNull(localeResolver,
+        "the locale-resolver must be present.");
   }
 
   /**

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
@@ -20,13 +20,12 @@ package com.github.jknack.handlebars.springmvc;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import java.io.IOException;
-import java.util.Locale;
 
 import org.springframework.context.MessageSource;
-import org.springframework.context.i18n.LocaleContextHolder;
 
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.springmvc.locale.LocaleResolver;
 
 /**
  * <p>
@@ -44,12 +43,9 @@ import com.github.jknack.handlebars.Options;
  * <li>args: Object. Optional</li>
  * <li>default: A default message. Optional.</li>
  * </ul>
- * This helper have a strong dependency to local-thread-bound variable for
- * accessing to the current user locale.
  *
  * @author edgar.espina
  * @since 0.5.5
- * @see LocaleContextHolder#getLocale()
  */
 public class MessageSourceHelper implements Helper<String> {
 
@@ -57,14 +53,20 @@ public class MessageSourceHelper implements Helper<String> {
    * A message source. Required.
    */
   private MessageSource messageSource;
+  
+  /**
+   * the locale resolver. Required.
+   */
+  private LocaleResolver localeResolver;
 
   /**
    * Creates a new {@link MessageSourceHelperTest}.
    *
    * @param messageSource The message source. Required.
    */
-  public MessageSourceHelper(final MessageSource messageSource) {
+  public MessageSourceHelper(final MessageSource messageSource, final LocaleResolver localeResolver) {
     this.messageSource = notNull(messageSource, "A message source is required.");
+    this.localeResolver = notNull(localeResolver, "A locale resolver is required.");
   }
 
   @Override
@@ -72,15 +74,6 @@ public class MessageSourceHelper implements Helper<String> {
       throws IOException {
     Object[] args = options.params;
     String defaultMessage = options.hash("default");
-    return messageSource.getMessage(code, args, defaultMessage, currentLocale());
-  }
-
-  /**
-   * Resolve the current user locale.
-   *
-   * @return The current user locale.
-   */
-  protected Locale currentLocale() {
-    return LocaleContextHolder.getLocale();
+    return messageSource.getMessage(code, args, defaultMessage, localeResolver.getCurrent(options));
   }
 }

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
@@ -32,18 +32,18 @@ import com.github.jknack.handlebars.springmvc.locale.LocaleResolver;
  * A helper that delegates to a {@link MessageSource} instance.
  * </p>
  * Usage:
- *
+ * 
  * <pre>
  *  {{message "code" args* [default="default message"] }}
  * </pre>
- *
+ * 
  * Where:
  * <ul>
  * <li>code: String literal. Required.</li>
  * <li>args: Object. Optional</li>
  * <li>default: A default message. Optional.</li>
  * </ul>
- *
+ * 
  * @author edgar.espina
  * @since 0.5.5
  */
@@ -53,7 +53,7 @@ public class MessageSourceHelper implements Helper<String> {
    * A message source. Required.
    */
   private MessageSource messageSource;
-  
+
   /**
    * the locale resolver. Required.
    */
@@ -61,12 +61,15 @@ public class MessageSourceHelper implements Helper<String> {
 
   /**
    * Creates a new {@link MessageSourceHelperTest}.
-   *
-   * @param messageSource The message source. Required.
+   * 
+   * @param messageSource
+   *          The message source. Required.
    */
-  public MessageSourceHelper(final MessageSource messageSource, final LocaleResolver localeResolver) {
+  public MessageSourceHelper(final MessageSource messageSource,
+      final LocaleResolver localeResolver) {
     this.messageSource = notNull(messageSource, "A message source is required.");
-    this.localeResolver = notNull(localeResolver, "A locale resolver is required.");
+    this.localeResolver = notNull(localeResolver,
+        "A locale resolver is required.");
   }
 
   @Override
@@ -74,6 +77,7 @@ public class MessageSourceHelper implements Helper<String> {
       throws IOException {
     Object[] args = options.params;
     String defaultMessage = options.hash("default");
-    return messageSource.getMessage(code, args, defaultMessage, localeResolver.getCurrent(options));
+    return messageSource.getMessage(code, args, defaultMessage,
+        localeResolver.getCurrent(options));
   }
 }

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
@@ -64,6 +64,7 @@ public class MessageSourceHelper implements Helper<String> {
    *
    * @param messageSource
    *          The message source. Required.
+   * @param localeResolver
    */
   public MessageSourceHelper(final MessageSource messageSource,
       final LocaleResolver localeResolver) {

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
@@ -32,18 +32,18 @@ import com.github.jknack.handlebars.springmvc.locale.LocaleResolver;
  * A helper that delegates to a {@link MessageSource} instance.
  * </p>
  * Usage:
- *
+ * 
  * <pre>
  *  {{message "code" args* [default="default message"] }}
  * </pre>
- *
+ * 
  * Where:
  * <ul>
  * <li>code: String literal. Required.</li>
  * <li>args: Object. Optional</li>
  * <li>default: A default message. Optional.</li>
  * </ul>
- *
+ * 
  * @author edgar.espina
  * @since 0.5.5
  */
@@ -61,10 +61,11 @@ public class MessageSourceHelper implements Helper<String> {
 
   /**
    * Creates a new {@link MessageSourceHelperTest}.
-   *
+   * 
    * @param messageSource
    *          The message source. Required.
    * @param localeResolver
+   *          The locale resolver. Required.
    */
   public MessageSourceHelper(final MessageSource messageSource,
       final LocaleResolver localeResolver) {

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
@@ -32,18 +32,18 @@ import com.github.jknack.handlebars.springmvc.locale.LocaleResolver;
  * A helper that delegates to a {@link MessageSource} instance.
  * </p>
  * Usage:
- * 
+ *
  * <pre>
  *  {{message "code" args* [default="default message"] }}
  * </pre>
- * 
+ *
  * Where:
  * <ul>
  * <li>code: String literal. Required.</li>
  * <li>args: Object. Optional</li>
  * <li>default: A default message. Optional.</li>
  * </ul>
- * 
+ *
  * @author edgar.espina
  * @since 0.5.5
  */
@@ -61,7 +61,7 @@ public class MessageSourceHelper implements Helper<String> {
 
   /**
    * Creates a new {@link MessageSourceHelperTest}.
-   * 
+   *
    * @param messageSource
    *          The message source. Required.
    * @param localeResolver

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/MessageSourceHelper.java
@@ -32,18 +32,18 @@ import com.github.jknack.handlebars.springmvc.locale.LocaleResolver;
  * A helper that delegates to a {@link MessageSource} instance.
  * </p>
  * Usage:
- * 
+ *
  * <pre>
  *  {{message "code" args* [default="default message"] }}
  * </pre>
- * 
+ *
  * Where:
  * <ul>
  * <li>code: String literal. Required.</li>
  * <li>args: Object. Optional</li>
  * <li>default: A default message. Optional.</li>
  * </ul>
- * 
+ *
  * @author edgar.espina
  * @since 0.5.5
  */
@@ -61,7 +61,7 @@ public class MessageSourceHelper implements Helper<String> {
 
   /**
    * Creates a new {@link MessageSourceHelperTest}.
-   * 
+   *
    * @param messageSource
    *          The message source. Required.
    */

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleContextHolderResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleContextHolderResolver.java
@@ -13,10 +13,10 @@ import com.github.jknack.handlebars.Options;
  * @see LocaleContextHolder#getLocale()
  */
 public class LocaleContextHolderResolver implements LocaleResolver {
- 
+
   @Override
   public Locale getCurrent(Options options) {
     return LocaleContextHolder.getLocale();
   }
-  
+
 }

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleContextHolderResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleContextHolderResolver.java
@@ -15,7 +15,7 @@ import com.github.jknack.handlebars.Options;
 public class LocaleContextHolderResolver implements LocaleResolver {
 
   @Override
-  public Locale getCurrent(Options options) {
+  public Locale getCurrent(final Options options) {
     return LocaleContextHolder.getLocale();
   }
 

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleContextHolderResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleContextHolderResolver.java
@@ -1,0 +1,22 @@
+package com.github.jknack.handlebars.springmvc.locale;
+
+import java.util.Locale;
+
+import org.springframework.context.i18n.LocaleContextHolder;
+
+import com.github.jknack.handlebars.Options;
+
+/**
+ * This resolver have a strong dependency to local-thread-bound variable for
+ * accessing to the current user locale.
+ *
+ * @see LocaleContextHolder#getLocale()
+ */
+public class LocaleContextHolderResolver implements LocaleResolver {
+ 
+  @Override
+  public Locale getCurrent(Options options) {
+    return LocaleContextHolder.getLocale();
+  }
+  
+}

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
@@ -5,11 +5,11 @@ import java.util.Locale;
 import com.github.jknack.handlebars.Options;
 
 /**
- * This is a generic interface for implementing a locale resolver 
+ * This is a generic interface for implementing a locale resolver
  *
  */
 public interface LocaleResolver {
 
   Locale getCurrent(final Options options);
-  
+
 }

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
@@ -5,11 +5,17 @@ import java.util.Locale;
 import com.github.jknack.handlebars.Options;
 
 /**
- * This is a generic interface for implementing a locale resolver
- *
+ * This is a generic interface for implementing
+ * a locale resolver.
  */
 public interface LocaleResolver {
 
+  /**
+   * Retrive the curren locale.
+   *
+   * @param options
+   * @return get the locale
+   */
   Locale getCurrent(final Options options);
 
 }

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
@@ -1,0 +1,15 @@
+package com.github.jknack.handlebars.springmvc.locale;
+
+import java.util.Locale;
+
+import com.github.jknack.handlebars.Options;
+
+/**
+ * This is a generic interface for implementing a locale resolver 
+ *
+ */
+public interface LocaleResolver {
+
+  Locale getCurrent(final Options options);
+  
+}

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/locale/LocaleResolver.java
@@ -14,6 +14,7 @@ public interface LocaleResolver {
    * Retrive the curren locale.
    *
    * @param options
+   *          This is the context that the locale resolve receives
    * @return get the locale
    */
   Locale getCurrent(final Options options);

--- a/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/MessageSourceHelperTest.java
+++ b/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/MessageSourceHelperTest.java
@@ -26,7 +26,7 @@ import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.springmvc.locale.LocaleContextHolderResolver;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Options.class, MessageSourceHelper.class, Context.class })
+@PrepareForTest({ Options.class, MessageSourceHelper.class, Context.class })
 public class MessageSourceHelperTest {
 
   @Test(expected = NullPointerException.class)
@@ -51,18 +51,17 @@ public class MessageSourceHelperTest {
     Template fn = createMock(Template.class);
 
     Options options = new Options.Builder(hbs, TagType.VAR, ctx, fn)
-        .setParams(params)
-        .setHash(hash)
-        .build();
-    
+        .setParams(params).setHash(hash).build();
+
     MessageSource messageSource = createMock(MessageSource.class);
-    expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
-        isA(Locale.class))).andReturn(message);
+    expect(
+        messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
+            isA(Locale.class))).andReturn(message);
 
     replay(messageSource, hash);
 
-    CharSequence result =
-        new MessageSourceHelper(messageSource, new LocaleContextHolderResolver()).apply(code, options);
+    CharSequence result = new MessageSourceHelper(messageSource,
+        new LocaleContextHolderResolver()).apply(code, options);
     assertEquals(message, result);
 
     verify(messageSource, hash);
@@ -75,7 +74,7 @@ public class MessageSourceHelperTest {
     String defaultMessage = null;
 
     // Options
-    Object[] params = {1, 2, 3 };
+    Object[] params = { 1, 2, 3 };
     @SuppressWarnings("unchecked")
     Map<String, Object> hash = createMock(Map.class);
     expect(hash.get("default")).andReturn(defaultMessage);
@@ -85,18 +84,17 @@ public class MessageSourceHelperTest {
     Template fn = createMock(Template.class);
 
     Options options = new Options.Builder(hbs, TagType.VAR, ctx, fn)
-        .setParams(params)
-        .setHash(hash)
-        .build();
-    
+        .setParams(params).setHash(hash).build();
+
     MessageSource messageSource = createMock(MessageSource.class);
-    expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
-        isA(Locale.class))).andReturn(message);
+    expect(
+        messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
+            isA(Locale.class))).andReturn(message);
 
     replay(messageSource, hash);
 
-    CharSequence result =
-        new MessageSourceHelper(messageSource, new LocaleContextHolderResolver()).apply(code, options);
+    CharSequence result = new MessageSourceHelper(messageSource,
+        new LocaleContextHolderResolver()).apply(code, options);
     assertEquals(message, result);
 
     verify(messageSource, hash);
@@ -109,7 +107,7 @@ public class MessageSourceHelperTest {
     String defaultMessage = "Aca viene el 3";
 
     // Options
-    Object[] params = {1, 2, 3 };
+    Object[] params = { 1, 2, 3 };
     @SuppressWarnings("unchecked")
     Map<String, Object> hash = createMock(Map.class);
     expect(hash.get("default")).andReturn(defaultMessage);
@@ -119,18 +117,17 @@ public class MessageSourceHelperTest {
     Template fn = createMock(Template.class);
 
     Options options = new Options.Builder(hbs, TagType.VAR, ctx, fn)
-        .setParams(params)
-        .setHash(hash)
-        .build();
-    
+        .setParams(params).setHash(hash).build();
+
     MessageSource messageSource = createMock(MessageSource.class);
-    expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
-        isA(Locale.class))).andReturn(message);
+    expect(
+        messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
+            isA(Locale.class))).andReturn(message);
 
     replay(messageSource, hash);
 
-    CharSequence result =
-        new MessageSourceHelper(messageSource, new LocaleContextHolderResolver()).apply(code, options);
+    CharSequence result = new MessageSourceHelper(messageSource,
+        new LocaleContextHolderResolver()).apply(code, options);
     assertEquals(message, result);
 
     verify(messageSource, hash);

--- a/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/MessageSourceHelperTest.java
+++ b/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/MessageSourceHelperTest.java
@@ -23,6 +23,7 @@ import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.TagType;
 import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.springmvc.locale.LocaleContextHolderResolver;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Options.class, MessageSourceHelper.class, Context.class })
@@ -30,7 +31,7 @@ public class MessageSourceHelperTest {
 
   @Test(expected = NullPointerException.class)
   public void nullMessageSource() {
-    new MessageSourceHelper(null);
+    new MessageSourceHelper(null, null);
   }
 
   @Test
@@ -53,7 +54,7 @@ public class MessageSourceHelperTest {
         .setParams(params)
         .setHash(hash)
         .build();
-
+    
     MessageSource messageSource = createMock(MessageSource.class);
     expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
         isA(Locale.class))).andReturn(message);
@@ -61,7 +62,7 @@ public class MessageSourceHelperTest {
     replay(messageSource, hash);
 
     CharSequence result =
-        new MessageSourceHelper(messageSource).apply(code, options);
+        new MessageSourceHelper(messageSource, new LocaleContextHolderResolver()).apply(code, options);
     assertEquals(message, result);
 
     verify(messageSource, hash);
@@ -87,7 +88,7 @@ public class MessageSourceHelperTest {
         .setParams(params)
         .setHash(hash)
         .build();
-
+    
     MessageSource messageSource = createMock(MessageSource.class);
     expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
         isA(Locale.class))).andReturn(message);
@@ -95,7 +96,7 @@ public class MessageSourceHelperTest {
     replay(messageSource, hash);
 
     CharSequence result =
-        new MessageSourceHelper(messageSource).apply(code, options);
+        new MessageSourceHelper(messageSource, new LocaleContextHolderResolver()).apply(code, options);
     assertEquals(message, result);
 
     verify(messageSource, hash);
@@ -121,7 +122,7 @@ public class MessageSourceHelperTest {
         .setParams(params)
         .setHash(hash)
         .build();
-
+    
     MessageSource messageSource = createMock(MessageSource.class);
     expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
         isA(Locale.class))).andReturn(message);
@@ -129,7 +130,7 @@ public class MessageSourceHelperTest {
     replay(messageSource, hash);
 
     CharSequence result =
-        new MessageSourceHelper(messageSource).apply(code, options);
+        new MessageSourceHelper(messageSource, new LocaleContextHolderResolver()).apply(code, options);
     assertEquals(message, result);
 
     verify(messageSource, hash);


### PR DESCRIPTION
If you have a custom behavior for handling the internationalization of your page, the default locale resolver is not usefull. With this i can be easy to define a custom behavior.
