### PR TITLE
Fixed the mismatch between Character#isWhitespace and [ \t]+

### DIFF
--- a/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
+++ b/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
@@ -13,10 +13,14 @@ lexer grammar HbsLexer;
     this.end = end;
   }
 
+  private boolean isNotSpace(int ch) {
+    return ch != ' ' && ch != '\t';
+  }
+
   private boolean consumeUntil(final String token) {
     int offset = 0;
     while(!isEOF(offset) && !ahead(token, offset) &&
-      !Character.isWhitespace(_input.LA(offset + 1))) {
+      isNotSpace(_input.LA(offset + 1))) {
       offset+=1;
     }
     if (offset == 0) {


### PR DESCRIPTION
In HbsLexer.g4#consumeUntil Character.isWhitespace is used for recognizing token delimiter. Character.isWhitespace matches whitespace (\u0020) and tab (\u0009), as well as other characters. But HbsLexer regards only  \u0020 and \u0009 as SPACE.

```
SPACE
 :
  [ \t]+
 ;
```

So, it causes SyntaxError if template contains \u000b (Vertical tab) or , \u3000 (IDEOGRAPHIC SPACE), and so on. 

I would appreciate if you could regard only ' ' and '\t'  as a delimiter instead of using Character.isWhitespace, in consumeUntil.
