### PR TITLE
Create JS-Helpers from sources after initialization

### DIFF
--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -175,11 +175,10 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
         } else if (helperSource instanceof Class) {
           handlebars.registerHelpers((Class<?>) helperSource);
         } else {
-          handlebars.registerHelpers(helperSource); 
+          handlebars.registerHelpers(helperSource);
         }
       }
-    }
-    catch (Exception ex) {
+    } catch (Exception ex) {
       System.out.println(ex.getMessage());
     }
 


### PR DESCRIPTION
Possible solution for issue #236 - added if/else blocks to create helpers via registerHelpers from javascript sources and changed method name of corresponding setHelpers to setHelperSources
