### PR TITLE
isContextRequired false for compatibility with portlet environment

### DIFF
--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsView.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsView.java
@@ -91,4 +91,9 @@ public class HandlebarsView extends AbstractTemplateView {
     this.valueResolvers = notEmpty(valueResolvers,
         "At least one value-resolver must be present.");
   }
+
+  @Override
+  protected boolean isContextRequired() {
+    return false;
+  }
 }


### PR DESCRIPTION
I was attempting to use handlebars-springmvc for a Spring MVC Portlet and was getting the error:

```
SEVERE: Servlet.service() for servlet view-servlet threw exception
java.lang.IllegalStateException: WebApplicationObjectSupport instance [com.github.jknack.handlebars.springmvc.HandlebarsView: name 'index'; URL [/html/index.hbs]] does not run within a ServletContext. Make sure the object is fully configured!
        at org.springframework.web.context.support.WebApplicationObjectSupport.getServletContext(WebApplicationObjectSupport.java:126)
        at org.springframework.web.servlet.view.AbstractTemplateView.renderMergedOutputModel(AbstractTemplateView.java:162)
        at org.springframework.web.servlet.view.AbstractView.render(AbstractView.java:250)
        at org.springframework.web.servlet.ViewRendererServlet.renderView(ViewRendererServlet.java:114)
        at org.springframework.web.servlet.ViewRendererServlet.processRequest(ViewRendererServlet.java:86)
        at org.springframework.web.servlet.ViewRendererServlet.doGet(ViewRendererServlet.java:66)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:621)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:722)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:305)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.doFilter(InvokerFilterChain.java:72)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilter.doFilter(InvokerFilter.java:73)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
        at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:684)
        at org.apache.catalina.core.ApplicationDispatcher.doInclude(ApplicationDispatcher.java:593)
        at org.apache.catalina.core.ApplicationDispatcher.include(ApplicationDispatcher.java:530)
        at com.liferay.portlet.PortletRequestDispatcherImpl.dispatch(PortletRequestDispatcherImpl.java:323)
        at com.liferay.portlet.PortletRequestDispatcherImpl.include(PortletRequestDispatcherImpl.java:105)
        at org.springframework.web.portlet.DispatcherPortlet.doRender(DispatcherPortlet.java:1137)
        at org.springframework.web.portlet.DispatcherPortlet.render(DispatcherPortlet.java:1092)
        at org.springframework.web.portlet.DispatcherPortlet.doRenderService(DispatcherPortlet.java:755)
        at org.springframework.web.portlet.FrameworkPortlet.processRequest(FrameworkPortlet.java:522)
        at org.springframework.web.portlet.FrameworkPortlet.doDispatch(FrameworkPortlet.java:470)
        at javax.portlet.GenericPortlet.render(GenericPortlet.java:233)
```

By overriding `isContextRequired` and returning `false` I was able to get Handlebars.java properly working as the view renderer for my portlet.  I am not 100% sure about the implications of returning `false` from `isContextRequired` so if there is a reason not to do this please share! In that case I can continue to do what I am doing now, which is subclass `com.github.jknack.handlebars.springmvc.HandlebarsView` and set my subclass in the viewRenderer bean definition:

```
<bean id="viewResolver" class="com.github.jknack.handlebars.springmvc.HandlebarsViewResolver">
  <property name="viewClass" value="edu.utexas.tacc.portlet.handlebars.springmvc.HandlebarsPortletView" />
  <property name="prefix" value="/html/" />
  <property name="suffix" value=".hbs" />
</bean>
```

Thanks!
