### PR TITLE
I18n: use system file separator

### DIFF
--- a/handlebars-maven-plugin/src/main/java/com/github/jknack/handlebars/maven/I18nJsPlugin.java
+++ b/handlebars-maven-plugin/src/main/java/com/github/jknack/handlebars/maven/I18nJsPlugin.java
@@ -134,7 +134,7 @@ public class I18nJsPlugin extends HandlebarsPlugin {
       hash.put("classLoader", new URLClassLoader(classpath, getClass().getClassLoader()));
     }
     // 3. get the base name from the bundle
-    String basename = FileUtils.removePath(this.bundle.replace(".", "/"));
+    String basename = FileUtils.removePath(this.bundle.replace(".", FileUtils.FS));
 
     Collections.sort(bundles);
     for (File bundle : bundles) {
@@ -195,9 +195,11 @@ public class I18nJsPlugin extends HandlebarsPlugin {
    */
   private List<File> bundles(final String bundle, final URL[] classpath) throws Exception {
     Set<File> bundles = new LinkedHashSet<File>();
+    String fs = FileUtils.FS;
     for (URL url : classpath) {
       File dir = new File(url.toURI());
-      bundles.addAll(FileUtils.getFiles(dir, bundle.replace(".", "/") + "*.properties", null));
+      bundles.addAll(FileUtils.getFiles(dir, bundle.replace(".", FileUtils.FS) + "*.properties",
+          null));
     }
     return new ArrayList<File>(bundles);
   }


### PR DESCRIPTION
On Windows machines, `"/"` causes problems with namespaced resource bundles, turning a bundle like:

```
com.foo.bar.web.resource.MessageResource
```

into

```
c:\myProject\src\resources\com/foo/bar/web/resource/MessageResource
```

So we end up with a `basename` on line 137 of `com/foo/bar/web/resource/MessageResource`, which blows up on line 145.

There's a pretty easy non-code workaround - in your pom.xml file, just replace this:

```
<bundle>com.foo.bar.web.resource.MessageResource</bundle>
```

with this:

```
<bundle>com${file.separator}foo${file.separator}bar${file.separator}web${file.separator}resource${file.separator}MessageResource</bundle>
```

But it seems better to handle it internally.
