### PR TITLE
I18nJS: HTML entity characters properly escaped in output

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/I18nHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/I18nHelper.java
@@ -270,7 +270,8 @@ public enum I18nHelper implements Helper<String> {
      * @return A valid I18n message.
      */
     private String message(final String message) {
-      Matcher matcher = pattern.matcher(message);
+      String escapedMessage = Handlebars.Utils.escapeExpression(message);
+      Matcher matcher = pattern.matcher(escapedMessage);
       StringBuffer result = new StringBuffer();
       while (matcher.find()) {
         matcher.appendReplacement(result, "{{arg" + matcher.group(1) + "}}");

--- a/handlebars/src/test/java/com/github/jknack/handlebars/I18NHelperTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/I18NHelperTest.java
@@ -22,6 +22,12 @@ public class I18NHelperTest extends AbstractTest {
     shouldCompileTo("{{i18n \"formatted\" \"Handlebars.java\"}}!", null, "Hi Handlebars.java!");
   }
 
+  @Test
+  public void escapeQuotes() throws IOException {
+    shouldCompileTo("{{i18n \"escaped\" \"Handlebars.java\"}}", null, "Hi, &quot;Handlebars.java&quot;, " +
+        "a &lt;tag&gt; &#x60;in backticks&#x60; &amp; other entities");
+  }
+
   @Test(expected = HandlebarsException.class)
   public void missingKeyError() throws IOException {
     shouldCompileTo("{{i18n \"missing\"}}", null, "error");
@@ -44,7 +50,9 @@ public class I18NHelperTest extends AbstractTest {
         "  I18n.translations = I18n.translations || {};\n" +
         "  I18n.translations['es_AR'] = {\n" +
         "    \"hello\": \"Hola\",\n" +
-        "    \"formatted\": \"Hi {{arg0}}\"\n" +
+        "    \"formatted\": \"Hi {{arg0}}\",\n" +
+        "    \"escaped\": \"Hi, &quot;{{arg0}}&quot;, " +
+        "a &lt;tag&gt; &#x60;in backticks&#x60; &amp; other &#x27;entities&#x27;\"\n" +
         "  };\n" +
         "</script>\n";
 

--- a/handlebars/src/test/resources/messages.properties
+++ b/handlebars/src/test/resources/messages.properties
@@ -1,3 +1,5 @@
 hello=Hi
 
 formatted=Hi {0}
+
+escaped=Hi, "{0}", a <tag> `in backticks` & other 'entities'


### PR DESCRIPTION
Use the provided `Handlebars.Utils.escapeExpression` method to escape HTML entities in JS output.

Currently, the resulting JS breaks if a double quote is encountered; this resolves that and other potential issues with various entities.
