### PR TITLE
fixed bug that 'with' spec is invalid.

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Options.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Options.java
@@ -17,14 +17,12 @@
  */
 package com.github.jknack.handlebars;
 
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
+
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Options available for {@link Helper#apply(Object, Options)}.
@@ -473,6 +471,9 @@ public class Options {
     }
     if (model instanceof Context) {
       return (Context) model;
+    }
+    if (model.getClass() == LinkedHashMap.class) {
+      return Context.newContext(model);
     }
     return Context.newContext(context, model);
   }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i314/Issue314.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i314/Issue314.java
@@ -1,0 +1,16 @@
+package com.github.jknack.handlebars.i314;
+
+import com.github.jknack.handlebars.AbstractTest;
+import org.junit.Test;
+import java.io.IOException;
+
+public class Issue314 extends AbstractTest {
+
+  @Test
+  public void withHelperSpec() throws IOException {
+    String context = "{ obj: { context: { one: 1, two: 2 } } }";
+
+    shouldCompileTo("{{#with obj}}{{context.one}}{{/with}}",     context, "1");
+    shouldCompileTo("{{#with obj}}{{obj.context.one}}{{/with}}", context, "");
+ }
+}


### PR DESCRIPTION
I fixed issue #314 bug 

So, following test code is success about 'with' spec.

```
@Test
public void withHelperSpec() throws IOException {
    String context = "{ obj: { context: { one: 1, two: 2 } } }";

    shouldCompileTo("{{#with obj}}{{context.one}}{{/with}}",     context, "1");
    shouldCompileTo("{{#with obj}}{{obj.context.one}}{{/with}}", context, "");
}
```
