### PR TITLE
Adjust comment handling to match Handlebars.js behavior

### DIFF
--- a/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
+++ b/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
@@ -35,29 +35,27 @@ lexer grammar HbsLexer;
   }
 
   private boolean comment(final String start, final String end) {
-    if (ahead(start + "!")) {
-      int offset = 0;
-      int level = -1;
-      while (!isEOF(offset)) {
-        if (ahead(end, offset)) {
-          if (level == 0) {
-            break;
-          } else {
-            level -= 1;
-          }
-        }
-        if (ahead(start, offset)) {
-          level += 1;
-        }
-        offset += 1;
-      }
-      offset += end.length();
-      // Since we found the text, increase the CharStream's index.
-      _input.seek(_input.index() + offset - 1);
-      getInterpreter().setCharPositionInLine(_tokenStartCharPositionInLine + offset - 1);
-      return true;
+    String commentClose;
+    if (ahead(start + "!--")) {
+      commentClose = "--" + end;
+    } else if (ahead(start + "!")) {
+      commentClose = end;
+    } else {
+      return false;
     }
-    return false;
+
+    int offset = 0;
+    while (!isEOF(offset)) {
+      if (ahead(commentClose, offset)) {
+        break;
+      }
+      offset += 1;
+    }
+    offset += commentClose.length();
+    // Since we found the text, increase the CharStream's index.
+    _input.seek(_input.index() + offset - 1);
+    getInterpreter().setCharPositionInLine(_tokenStartCharPositionInLine + offset - 1);
+    return true;
   }
 
   private boolean varEscape(final String start, final String end) {

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i310/Issue310.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i310/Issue310.java
@@ -1,0 +1,20 @@
+package com.github.jknack.handlebars.i310;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.github.jknack.handlebars.AbstractTest;
+
+public class Issue310 extends AbstractTest {
+
+  @Test
+  public void commentWithClosingMustache() throws IOException {
+    shouldCompileTo("{{!-- not a var}} --}}", $, "");
+  }
+
+  @Test
+  public void commentNotNestable() throws IOException {
+    shouldCompileTo("{{! {{not}} a var}}", $, " a var}}");
+  }
+}


### PR DESCRIPTION
Instead of relying on properly nested delimiters inside comments, we
adopt the comment behavior in Handlebars.js:
- `{{! }}` comments end with the first `}}` encountered, no nested
  braces are allowed.
- `{{!-- --}}` comments allow any number of `}}` whether they are
  properly nested or not.

Fixes #310
