### PR TITLE
Adding support for 1-based index with the @index_1 psuedo variable

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/EachHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/EachHelper.java
@@ -111,6 +111,8 @@ public class EachHelper implements Helper<Object> {
             .combine("@last", last ? "last" : "")
             .combine("@odd", even ? "" : "odd")
             .combine("@even", even ? "even" : "")
+            // 1-based index
+            .combine("@index_1", index + 1)
             .build();
         buffer.append(options.fn(current));
         current.destroy();

--- a/handlebars/src/test/java/com/github/jknack/handlebars/PseudoVarsTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/PseudoVarsTest.java
@@ -21,7 +21,7 @@ public class PseudoVarsTest {
   @Test
   public void list() throws IOException {
     String input =
-        "{{#list}}i={{@index}}\neven={{@even}}\nodd={{@odd}}\nfirst={{@first}}\nlast={{@last}}\n{{/list}}";
+        "{{#list}}i={{@index}}\neven={{@even}}\nodd={{@odd}}\nfirst={{@first}}\nlast={{@last}}\ni+1={{@index_1}}\n{{/list}}";
     Handlebars handlebars = new Handlebars();
 
     assertEquals("i=0\n" +
@@ -29,16 +29,19 @@ public class PseudoVarsTest {
         "odd=\n" +
         "first=first\n" +
         "last=\n" +
+        "i+1=1\n" +
         "i=1\n" +
         "even=\n" +
         "odd=odd\n" +
         "first=\n" +
         "last=\n" +
+        "i+1=2\n" +
         "i=2\n" +
         "even=even\n" +
         "odd=\n" +
         "first=\n" +
-        "last=last\n",
+        "last=last\n" +
+        "i+1=3\n",
         handlebars.compileInline(input).apply(new Object() {
           @SuppressWarnings("unused")
           public List<String> getList() {


### PR DESCRIPTION
I'm happy to rename the psuedo variable, but this is a feature that is sorely missed. I went with this syntax Ember uses: http://mozmonkey.com/2014/03/ember-getting-the-index-in-each-loops/. I like this much more than other solutions that involve creating a math helper. Let me know what you think!

Eli