### PR TITLE
Fix joining for empty lists

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/StringHelpers.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/StringHelpers.java
@@ -157,6 +157,14 @@ public enum StringHelpers implements Helper<Object> {
   join {
     @SuppressWarnings("rawtypes")
     @Override
+    public CharSequence apply(final Object context, final Options options) {
+      if (options.isFalsy(context)) {
+        return "";
+      }
+      return safeApply(context, options);
+    }
+
+    @Override
     protected CharSequence safeApply(final Object context, final Options options) {
       int separatorIdx = options.params.length - 1;
       Object separator = options.param(separatorIdx, null);

--- a/handlebars/src/test/java/com/github/jknack/handlebars/helper/StringHelpersTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/helper/StringHelpersTest.java
@@ -25,10 +25,7 @@ import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
@@ -149,7 +146,13 @@ public class StringHelpersTest extends AbstractTest {
   @Test
   public void joinIterable() throws IOException {
     shouldCompileTo("{{{join this \", \"}}}", Arrays.asList("6", "7", "8"),
-        $("join", StringHelpers.join), "6, 7, 8");
+            $("join", StringHelpers.join), "6, 7, 8");
+  }
+
+  @Test
+  public void joinEmptyList() throws IOException {
+    shouldCompileTo("{{{join this \", \"}}}", Collections.emptyList(),
+            $("join", StringHelpers.join), "");
   }
 
   @Test
@@ -483,6 +486,7 @@ public class StringHelpersTest extends AbstractTest {
   public void nullContext() throws IOException {
     Set<Helper<Object>> helpers = new LinkedHashSet<Helper<Object>>(Arrays.asList(StringHelpers
         .values()));
+    helpers.remove(StringHelpers.join);
     helpers.remove(StringHelpers.yesno);
     helpers.remove(StringHelpers.defaultIfEmpty);
 
@@ -503,6 +507,7 @@ public class StringHelpersTest extends AbstractTest {
   public void nullContextWithDefault() throws IOException {
     Set<Helper<Object>> helpers = new LinkedHashSet<Helper<Object>>(Arrays.asList(StringHelpers
         .values()));
+    helpers.remove(StringHelpers.join);
     helpers.remove(StringHelpers.yesno);
     helpers.remove(StringHelpers.defaultIfEmpty);
 
@@ -524,6 +529,7 @@ public class StringHelpersTest extends AbstractTest {
   public void nullContextWithNumber() throws IOException {
     Set<Helper<Object>> helpers = new LinkedHashSet<Helper<Object>>(Arrays.asList(StringHelpers
         .values()));
+    helpers.remove(StringHelpers.join);
     helpers.remove(StringHelpers.yesno);
     helpers.remove(StringHelpers.defaultIfEmpty);
 


### PR DESCRIPTION
I found an unexpected behavior where empty list joined as single comma. I attached the test case to reproduce it
