### PR TITLE
Add a ValueResolver for fluent interfaces

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/MethodValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/MethodValueResolver.java
@@ -17,12 +17,12 @@
  */
 package com.github.jknack.handlebars.context;
 
+import com.github.jknack.handlebars.ValueResolver;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
-import com.github.jknack.handlebars.ValueResolver;
 
 /**
  * A specialization of {@link MemberValueResolver} with lookup and invocation
@@ -41,7 +41,8 @@ public class MethodValueResolver extends MemberValueResolver<Method> {
 
   @Override
   public boolean matches(final Method method, final String name) {
-    return isPublic(method) && method.getName().equals(name);
+    int parameterCount = method.getParameterTypes().length;
+    return isPublic(method) && method.getName().equals(name) && parameterCount == 0;
   }
 
   @Override

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ValueResolverTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ValueResolverTest.java
@@ -17,8 +17,11 @@
  */
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import com.github.jknack.handlebars.context.FieldValueResolver;
+import com.github.jknack.handlebars.context.JavaBeanValueResolver;
+import com.github.jknack.handlebars.context.MapValueResolver;
+import com.github.jknack.handlebars.context.MethodValueResolver;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -26,15 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-
-import com.github.jknack.handlebars.Context;
-import com.github.jknack.handlebars.Handlebars;
-import com.github.jknack.handlebars.Template;
-import com.github.jknack.handlebars.context.FieldValueResolver;
-import com.github.jknack.handlebars.context.JavaBeanValueResolver;
-import com.github.jknack.handlebars.context.MapValueResolver;
-import com.github.jknack.handlebars.context.MethodValueResolver;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Unit test for {@link Context}.
@@ -62,6 +58,14 @@ public class ValueResolverTest {
     public String getChildProperty() {
       return child;
     }
+
+    public String base() {
+      return base;
+    }
+
+    public String child() {
+      return child;
+    }
   }
 
   @Test
@@ -84,6 +88,8 @@ public class ValueResolverTest {
     assertNotNull(context);
     assertEquals("a", context.get("getBaseProperty"));
     assertEquals("b", context.get("getChildProperty"));
+    assertEquals("a", context.get("base"));
+    assertEquals("b", context.get("child"));
   }
 
   @Test


### PR DESCRIPTION
We're using fluent interface getters and setters, like so:
```java
public class Foo {
    private String bar;

    public String bar() {
        return this.bar;
    }
    public Foo bar(final String bar) {
        this.id = id;
        return this;
    }
}
```
Here's the ValueResolver we wrote for them. Please review the tests. I added a couple, but it wasn't clear to me to which of the existing methods I should add the FluentInterfaceValueResolver. Please decline this PR with suggestions for where to create more tests or which tests to expand upon :)