### PR TITLE
set default locale of surefire test JVM to en_US

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.16</version>
         <configuration>
+          <!-- set default locale of the test JVM to en_US because some tests expect e.g. the dollar sign as currency symbol -->
+          <argLine>-Duser.language=en -Duser.country=US</argLine>
           <includes>
             <include>**/*Test.java</include>
             <include>**/Issue*.java</include>


### PR DESCRIPTION
as some tests expect e.g. dollar sign as currency symbol