### PR TITLE
Use user defined type's class loader, when creating proxy

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
@@ -238,7 +238,7 @@ abstract class BaseTemplate implements Template {
    * @return A new {@link TypeSafeTemplate}.
    */
   private static Object newTypeSafeTemplate(final Class<?> rootType, final Template template) {
-    return Proxy.newProxyInstance(template.getClass().getClassLoader(), new Class[]{rootType },
+    return Proxy.newProxyInstance(rootType.getClassLoader(), new Class[]{rootType },
         new InvocationHandler() {
           private Map<String, Object> attributes = new HashMap<String, Object>();
 


### PR DESCRIPTION
In a webapp framework, such as Playframework, class loader loading the handlebars library, may not be the same class loader as one's loading user defined interfaces.  This fixes that issue.