### PR TITLE
Fix for issue #403

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
@@ -17,16 +17,21 @@
  */
 package com.github.jknack.handlebars.context;
 
-import static org.apache.commons.lang3.Validate.notNull;
+import com.github.jknack.handlebars.ValueResolver;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.github.jknack.handlebars.ValueResolver;
+import static org.apache.commons.lang3.Validate.notNull;
 
 /**
  * A specialization of {@link ValueResolver} that is built on top of reflections
@@ -212,15 +217,39 @@ public abstract class MemberValueResolver<M extends Member>
    */
   protected abstract String memberName(M member);
 
+  /**
+   *  A value type used as the key for cache of {@link Member}.
+   *  Consists of a class instance and an optional name.
+   */
   private static class CacheKey {
+    /**
+     * The class of the member this cache key is for.
+     */
     private final Class clazz;
+
+    /**
+     * Optional name of the the member this cache key is for.
+     */
     private final String name;
 
-    public CacheKey(Class clazz) {
+    /**
+     * Constructor which should be used when the created key is to be used for all members of
+     * a class.
+     *
+     * @param clazz The class the constructed key is for.
+     */
+    public CacheKey(final Class clazz) {
       this(clazz, null);
     }
 
-    public CacheKey(Class clazz, String name) {
+    /**
+     * The constructor which should be used when the created key is to be used for a specific
+     * member of a class.
+     *
+     * @param clazz The class of the member the constructed cache key is for.
+     * @param name The name of the the member the constructed key is for.
+     */
+    public CacheKey(final Class clazz, final String name) {
       this.clazz = clazz;
       this.name = name;
     }
@@ -231,7 +260,7 @@ public abstract class MemberValueResolver<M extends Member>
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(final Object obj) {
       if (obj instanceof CacheKey) {
         CacheKey other = (CacheKey) obj;
         return equal(clazz, other.clazz) && equal(name, other.name);
@@ -239,8 +268,16 @@ public abstract class MemberValueResolver<M extends Member>
       return false;
     }
 
-    private static boolean equal(Object a, Object b) {
-      return a == b || a != null && a.equals(b);
+    /**
+     * A helper useful when implementing {@link java.lang.Object#equals} according to the
+     * contract of that method as outlined in Chapter 3, Item 8 of Effective Java by Joshua Bloch.
+     *
+     * @param first The first object checked for equality against the second object.
+     * @param second The second object checked for equality against the first object.
+     * @return true if the first and second arguments are equal
+     */
+    private static boolean equal(final Object first, final Object second) {
+      return first == second || first != null && first.equals(second);
     }
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/context/MultipleClassLoadersMethodValueResolverTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/context/MultipleClassLoadersMethodValueResolverTest.java
@@ -1,0 +1,51 @@
+package com.github.jknack.handlebars.context;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.apache.commons.io.FileUtils.copyURLToFile;
+
+public class MultipleClassLoadersMethodValueResolverTest {
+
+  private final static String CLASS_NAME = "TestClass";
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private MethodValueResolver resolver = new MethodValueResolver();
+
+  @Before
+  public void compileTestClass() throws IOException, URISyntaxException {
+    String sourceFileName = CLASS_NAME + ".java";
+    File sourceFile = temp.newFile(sourceFileName);
+
+    URL sourceFileResourceUrl = getClass().getResource(sourceFileName).toURI().toURL();
+    copyURLToFile(sourceFileResourceUrl, sourceFile);
+
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    compiler.run(null, null, null, "-d", temp.getRoot().getAbsolutePath(), sourceFile.getAbsolutePath());
+  }
+
+  @Test
+  public void canResolveMethodsFromTheSameClassLoadedByDistinctClassLoaders() throws Exception {
+    Assert.assertEquals(resolver.resolve(loadTestClassWithDistinctClassLoader().newInstance(), "getField"), "value");
+    Assert.assertEquals(resolver.resolve(loadTestClassWithDistinctClassLoader().newInstance(), "getField"), "value");
+  }
+
+  private Class<?> loadTestClassWithDistinctClassLoader() throws Exception {
+    URL[] classpath = {temp.getRoot().toURI().toURL()};
+    URLClassLoader loader = new URLClassLoader(classpath);
+    return loader.loadClass(CLASS_NAME);
+  }
+}

--- a/handlebars/src/test/resources/com/github/jknack/handlebars/context/TestClass.java
+++ b/handlebars/src/test/resources/com/github/jknack/handlebars/context/TestClass.java
@@ -1,0 +1,5 @@
+public class TestClass {
+  public String getField() {
+    return "value";
+  }
+}


### PR DESCRIPTION
Contains a test and a fix for the cache in `MethodValueResolver` to handle members of the same class loaded by distinct class loaders.