### PR TITLE
Rhino optimization option

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -250,7 +250,7 @@ public class Handlebars implements HelperRegistry {
             html.append("&#x60;");
             break;
           case '=':
-            html.append("&#x3D");
+            html.append("&#x3D;");
             break;
           case '&':
             html.append("&amp;");

--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
@@ -249,4 +249,18 @@ public class DefaultHelperRegistry implements HelperRegistry {
     return this;
   }
 
+
+	/**
+	 * Set the handlebars Js. This operation will override previously registered
+	 * handlebars Js.
+	 *
+	 * @param handlebarsJs The handlebars Js. Required.
+	 * @return This DefaultHelperRegistry object.
+	 */
+	public DefaultHelperRegistry with(HandlebarsJs handlebarsJs){
+		notNull(handlebarsJs, "The handlebarsJs is required.");
+		this.handlebarsJs = handlebarsJs;
+		return this;
+	}
+
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/js/RhinoHandlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/js/RhinoHandlebars.java
@@ -43,6 +43,11 @@ import com.github.jknack.handlebars.js.HandlebarsJs;
  */
 public class RhinoHandlebars extends HandlebarsJs {
 
+	/**
+	 * The optimization level of rhino,  default -1.
+	 * Please refer to https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Optimization
+	 */
+	private int optimizationLevel = -1;
   /**
    * Better integration between java collections/arrays and js arrays. It check for data types
    * at access time and convert them when necessary.
@@ -219,7 +224,19 @@ public class RhinoHandlebars extends HandlebarsJs {
     super(helperRegistry);
   }
 
-  /**
+	/**
+	 * Creates a new {@link RhinoHandlebars}.
+	 *
+	 * @param helperRegistry The handlebars object.
+	 * @param optimizationLevel The optimization level of rhino.
+	 */
+	public RhinoHandlebars(final HelperRegistry helperRegistry, int optimizationLevel) {
+		super(helperRegistry);
+		this.optimizationLevel = optimizationLevel;
+	}
+
+
+	/**
    * Register a helper in the helper registry.
    *
    * @param name The helper's name. Required.
@@ -273,7 +290,7 @@ public class RhinoHandlebars extends HandlebarsJs {
    */
   private org.mozilla.javascript.Context newContext() {
     org.mozilla.javascript.Context ctx = org.mozilla.javascript.Context.enter();
-    ctx.setOptimizationLevel(-1);
+    ctx.setOptimizationLevel(optimizationLevel);
     ctx.setErrorReporter(new ToolErrorReporter(false));
     ctx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_1_8);
     return ctx;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/js/HandlebarsJs.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/js/HandlebarsJs.java
@@ -85,16 +85,27 @@ public abstract class HandlebarsJs {
    * @return A new {@link HandlebarsJs} object.
    */
   public static HandlebarsJs create(final HelperRegistry helperRegistry) {
-    try {
-      ClassUtils.getClass("org.mozilla.javascript.Context");
-      return new RhinoHandlebars(helperRegistry);
-    } catch (final Exception ex) {
-      return new HandlebarsJs(helperRegistry) {
-        @Override
-        public void registerHelpers(final String filename, final String source) throws Exception {
-          throw new IllegalStateException("Rhino isn't on the classpath", ex);
-        }
-      };
-    }
+    return createRhino(helperRegistry,-1);
   }
+
+	/**
+	 * Creates a {@link HandlebarsJs} object.
+	 *
+	 * @param helperRegistry The helperRegistry object. Required.
+	 * @param optimizationLevel The optimization level of rhino.
+	 * @return A new {@link HandlebarsJs} object.
+	 */
+	public static HandlebarsJs createRhino(final HelperRegistry helperRegistry, int optimizationLevel) {
+		try {
+			ClassUtils.getClass("org.mozilla.javascript.Context");
+			return new RhinoHandlebars(helperRegistry, optimizationLevel);
+		} catch (final Exception ex) {
+			return new HandlebarsJs(helperRegistry) {
+				@Override
+				public void registerHelpers(final String filename, final String source) throws Exception {
+					throw new IllegalStateException("Rhino isn't on the classpath", ex);
+				}
+			};
+		}
+	}
 }


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Optimization , different optimization level affect  js execution, adding an option to setting optimization level is necessary。  Example： 
```java
DefaultHelperRegistry registry = new DefaultHelperRegistry(); 

Handlebars.with(registry.with(HandlebarsJs.createRhino(registry,9)));
```
 
