### PR TITLE
Faster html escaping

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -228,38 +228,55 @@ public class Handlebars implements HelperRegistry {
       }
       // Don't escape SafeStrings, since they're already safe
       if (input instanceof SafeString) {
-        return input.toString();
+        return ((SafeString) input).content;
       }
-      StringBuilder html = new StringBuilder(input.length());
-      for (int i = 0; i < input.length(); i++) {
-        char ch = input.charAt(i);
-        switch (ch) {
+      StringBuilder out = null;
+      int prev = 0;
+      final int length = input.length();
+      for (int i = 0; i < length; i++) {
+        String newCh = null;
+        switch (input.charAt(i)) {
           case '<':
-            html.append("&lt;");
+            newCh = "&lt;";
             break;
           case '>':
-            html.append("&gt;");
+            newCh = "&gt;";
             break;
           case '"':
-            html.append("&quot;");
+            newCh = "&quot;";
             break;
           case '\'':
-            html.append("&#x27;");
+            newCh = "&#x27;";
             break;
           case '`':
-            html.append("&#x60;");
+            newCh = "&#x60;";
             break;
           case '=':
-            html.append("&#x3D;");
+            newCh = "&#x3D;";
             break;
           case '&':
-            html.append("&amp;");
+            newCh = "&amp;";
             break;
           default:
-            html.append(ch);
+        }
+        if (newCh != null) {
+          if (out == null) {
+            out = new StringBuilder(length + 10);
+          }
+          if (prev < i) {
+            out.append(input, prev, i);
+          }
+          out.append(newCh);
+          prev = i + 1;
         }
       }
-      return html.length() == input.length() ? input : html;
+      if (out == null) {
+        return input;
+      }
+      if (prev < length) {
+        out.append(input, prev, length);
+      }
+      return out;
     }
   }
 


### PR DESCRIPTION
This implementation provides faster html escaping by:
* appending chunks of text
* allocating StringBuilder only if needed

| Benchmark                   | (count) | (margin) | (p1) | (p2) | (p3) | (p4) | (p5) | Mode  | Cnt | Score              | Units |
|-----------------------------|---------|----------|------|------|------|------|------|-------|-----|--------------------|-------|
| MyBenchmark.testMyEsc_Empty | 100     | 10       | 1    | 10   | 1    | 1    | 1    | thrpt | 5   | 3109,824 ± 427,303 | ops/s |
| MyBenchmark.testStd_Empty   | 100     | 10       | 1    | 10   | 1    | 1    | 1    | thrpt | 5   | 1817,867 ± 159,256 | ops/s |

https://gist.github.com/soldierkam/f429bfb92a3f41b7f9e2