### PR TITLE
Decrease allocation rate

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/PathCompiler.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/PathCompiler.java
@@ -17,7 +17,7 @@
  */
 package com.github.jknack.handlebars;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,7 +77,7 @@ public final class PathCompiler {
    * @return A path representation of the property (array based).
    */
   private static List<PathExpression> parse(final String path) {
-    LinkedList<PathExpression> resolvers = new LinkedList<>();
+    List<PathExpression> resolvers = new ArrayList<>();
     if ("this".equals(path) || "./".equals(path) || ".".equals(path)) {
       resolvers.add(new ResolveThisPath(path));
       return resolvers;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
@@ -22,7 +22,6 @@ import static org.apache.commons.lang3.Validate.notNull;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -256,7 +255,9 @@ public abstract class MemberValueResolver<M extends Member>
 
     @Override
     public int hashCode() {
-      return Arrays.hashCode(new Object[] {clazz, name});
+      int result = clazz.hashCode();
+      result = 31 * result + (name != null ? name.hashCode() : 0);
+      return result;
     }
 
     @Override

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/MethodValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/MethodValueResolver.java
@@ -38,6 +38,10 @@ public class MethodValueResolver extends MemberValueResolver<Method> {
    * The default instance.
    */
   public static final ValueResolver INSTANCE = new MethodValueResolver();
+  /**
+   * Args for getters.
+   */
+  private static final Object[] EMPTY_ARGS = new Object[0];
 
   @Override
   public boolean matches(final Method method, final String name) {
@@ -48,7 +52,7 @@ public class MethodValueResolver extends MemberValueResolver<Method> {
   @Override
   protected Object invokeMember(final Method member, final Object context) {
     try {
-      return member.invoke(context);
+      return member.invoke(context, EMPTY_ARGS);
     } catch (InvocationTargetException ex) {
       Throwable cause = ex.getCause();
       if (cause instanceof RuntimeException) {

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateList.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateList.java
@@ -22,7 +22,6 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -42,10 +41,10 @@ class TemplateList extends BaseTemplate implements Iterable<Template> {
   /**
    * The list of child templates.
    */
-  private final List<Template> nodes = new LinkedList<>();
+  private final List<Template> nodes = new ArrayList<>();
 
   /** Keep track of direct decorators and run them before merge. */
-  private final List<BaseTemplate> decorators = new LinkedList<>();
+  private final List<BaseTemplate> decorators = new ArrayList<>();
 
   /** True, if this block has decorators. */
   private boolean decorate;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/path/DataPath.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/path/DataPath.java
@@ -32,6 +32,8 @@ public class DataPath implements PathExpression {
 
   /** Property name. */
   private String name;
+  /** Property name without @. */
+  private String nameWithoutAtSymbol;
 
   /**
    * Creates a new {@link DataPath} expression.
@@ -40,6 +42,7 @@ public class DataPath implements PathExpression {
    */
   public DataPath(final String name) {
     this.name = name;
+    this.nameWithoutAtSymbol = name.substring(1);
   }
 
   @Override
@@ -49,7 +52,7 @@ public class DataPath implements PathExpression {
     Object value = resolver.resolve(data, name);
     if (value == null) {
       // without @
-      value = resolver.resolve(data, name.substring(1));
+      value = resolver.resolve(data, nameWithoutAtSymbol);
     }
     return chain.next(resolver, context, value);
   }


### PR DESCRIPTION
This patch decrease allocation rate by reusing objects that are always the same. It also change LinkedList to ArrayList to improve memory cache hit rate.
The code was tested with https://github.com/mbosecke/template-benchmark
Before:
> Result "benchmark":
  13155,824 ±(99.9%) 198,298 ops/s [Average]
  (min, avg, max) = (11222,481, 13155,824, 14072,970), stdev = 723,454
  CI (99.9%): [12957,525, 13354,122] (assumes normal distribution)

After:
> Result "benchmark":
  14257,884 ±(99.9%) 172,732 ops/s [Average]
  (min, avg, max) = (12057,893, 14257,884, 15258,548), stdev = 630,180
  CI (99.9%): [14085,152, 14430,616] (assumes normal distribution)

So on my machine it gives ~8% more throughput. 