### PR TITLE
[#493] Instantiate HandlebarsViewResolver with Handlebars Object

### DIFF
--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -143,6 +143,29 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
   }
 
   /**
+   * Creates a new {@link HandlebarsViewResolver} that utilizes the parameter handlebars for the underlying template
+   * lifecycle management.
+   *
+   * @param handlebars The {@link Handlebars} instance used for template lifecycle management. Required.
+   */
+  public HandlebarsViewResolver(Handlebars handlebars) {
+    this(handlebars, HandlebarsView.class);
+  }
+
+  /**
+   * Creates a new {@link HandlebarsViewResolver} that utilizes the parameter handlebars for the underlying template
+   * lifecycle management.
+   *
+   * @param handlebars The {@link Handlebars} instance used for template lifecycle management. Required.
+   * @param viewClass The view's class. Required.
+   */
+  public HandlebarsViewResolver(Handlebars handlebars, final Class<? extends HandlebarsView> viewClass) {
+    this(viewClass);
+
+    this.handlebars = handlebars;
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
@@ -189,12 +212,15 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
 
   @Override
   public void afterPropertiesSet() {
-    // Creates a new template loader.
-    URLTemplateLoader templateLoader = createTemplateLoader(getApplicationContext());
+    // If no handlebars object was passed in as a constructor parameter
+    if(handlebars == null) {
+      // Creates a new template loader.
+      URLTemplateLoader templateLoader = createTemplateLoader(getApplicationContext());
 
-    // Creates a new handlebars object.
-    handlebars = notNull(createHandlebars(templateLoader),
-        "A handlebars object is required.");
+      // Creates a new handlebars object.
+      handlebars = notNull(createHandlebars(templateLoader),
+              "A handlebars object is required.");
+    }
 
     handlebars.with(registry);
 

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -143,23 +143,26 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
   }
 
   /**
-   * Creates a new {@link HandlebarsViewResolver} that utilizes the parameter handlebars for the underlying template
-   * lifecycle management.
+   * Creates a new {@link HandlebarsViewResolver} that utilizes the parameter handlebars for the
+   * underlying template lifecycle management.
    *
-   * @param handlebars The {@link Handlebars} instance used for template lifecycle management. Required.
+   * @param handlebars The {@link Handlebars} instance used for template lifecycle management.
+   *                   Required.
    */
-  public HandlebarsViewResolver(Handlebars handlebars) {
+  public HandlebarsViewResolver(final Handlebars handlebars) {
     this(handlebars, HandlebarsView.class);
   }
 
   /**
-   * Creates a new {@link HandlebarsViewResolver} that utilizes the parameter handlebars for the underlying template
-   * lifecycle management.
+   * Creates a new {@link HandlebarsViewResolver} that utilizes the parameter handlebars for the
+   * underlying template lifecycle management.
    *
-   * @param handlebars The {@link Handlebars} instance used for template lifecycle management. Required.
+   * @param handlebars The {@link Handlebars} instance used for template lifecycle management.
+   *                   Required.
    * @param viewClass The view's class. Required.
    */
-  public HandlebarsViewResolver(Handlebars handlebars, final Class<? extends HandlebarsView> viewClass) {
+  public HandlebarsViewResolver(final Handlebars handlebars,
+                                final Class<? extends HandlebarsView> viewClass) {
     this(viewClass);
 
     this.handlebars = handlebars;
@@ -213,7 +216,7 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
   @Override
   public void afterPropertiesSet() {
     // If no handlebars object was passed in as a constructor parameter
-    if(handlebars == null) {
+    if (handlebars == null) {
       // Creates a new template loader.
       URLTemplateLoader templateLoader = createTemplateLoader(getApplicationContext());
 

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -218,7 +218,7 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
     // If no handlebars object was passed in as a constructor parameter
     if (handlebars == null) {
       // Creates a new template loader.
-      URLTemplateLoader templateLoader = createTemplateLoader(getApplicationContext());
+      TemplateLoader templateLoader = createTemplateLoader(getApplicationContext());
 
       // Creates a new handlebars object.
       handlebars = notNull(createHandlebars(templateLoader),
@@ -286,12 +286,12 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
   }
 
   /**
-   * Creates a new {@link Handlebars} object using the {@link SpringTemplateLoader}.
+   * Creates a new {@link Handlebars} object using the parameter {@link TemplateLoader}.
    *
    * @param templateLoader A template loader.
    * @return A new handlebar's object.
    */
-  protected Handlebars createHandlebars(final URLTemplateLoader templateLoader) {
+  protected Handlebars createHandlebars(final TemplateLoader templateLoader) {
     return new Handlebars(templateLoader);
   }
 
@@ -301,7 +301,7 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
    * @param context The application's context.
    * @return A new template loader.
    */
-  protected URLTemplateLoader createTemplateLoader(final ApplicationContext context) {
+  protected TemplateLoader createTemplateLoader(final ApplicationContext context) {
     URLTemplateLoader templateLoader = new SpringTemplateLoader(context);
     // Override prefix and suffix.
     templateLoader.setPrefix(getPrefix());

--- a/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsApp.java
+++ b/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsApp.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.github.jknack.handlebars.Handlebars;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +17,9 @@ import com.github.jknack.handlebars.Options;
 
 @Configuration
 public class HandlebarsApp {
+
+  @Autowired
+  ApplicationContext applicationContext;
 
   @Bean
   public HandlebarsViewResolver viewResolver() {
@@ -34,6 +40,17 @@ public class HandlebarsApp {
     viewResolver.setCache(false);
 
     viewResolver.setBindI18nToMessageSource(true);
+
+    return viewResolver;
+  }
+
+  @Bean
+  public HandlebarsViewResolver parameterizedHandlebarsViewResolver() {
+    HandlebarsViewResolver viewResolver = new HandlebarsViewResolver(new Handlebars(
+        new SpringTemplateLoader(applicationContext)));
+
+    // no cache for testing
+    viewResolver.setCache(false);
 
     return viewResolver;
   }

--- a/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolverIntegrationTest.java
+++ b/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolverIntegrationTest.java
@@ -30,6 +30,10 @@ public class HandlebarsViewResolverIntegrationTest {
   @Qualifier("viewResolverWithoutMessageHelper")
   HandlebarsViewResolver viewResolverWithoutMessageHelper;
 
+  @Autowired
+  @Qualifier("parameterizedHandlebarsViewResolver")
+  HandlebarsViewResolver parameterizedHandlebarsViewResolver;
+
   @Test
   public void getHandlebars() throws Exception {
     assertNotNull(viewResolver);
@@ -40,6 +44,14 @@ public class HandlebarsViewResolverIntegrationTest {
   public void resolveView() throws Exception {
     assertNotNull(viewResolver);
     View view = viewResolver.resolveViewName("template", Locale.getDefault());
+    assertNotNull(view);
+    assertEquals(HandlebarsView.class, view.getClass());
+  }
+
+  @Test
+  public void resolveViewWithParameterized() throws Exception {
+    assertNotNull(parameterizedHandlebarsViewResolver);
+    View view = parameterizedHandlebarsViewResolver.resolveViewName("template", Locale.getDefault());
     assertNotNull(view);
     assertEquals(HandlebarsView.class, view.getClass());
   }
@@ -56,6 +68,18 @@ public class HandlebarsViewResolverIntegrationTest {
     }
   }
 
+  @Test
+  public void resolveViewWithFallbackParameterized() throws Exception {
+    try {
+      assertNotNull(parameterizedHandlebarsViewResolver);
+      parameterizedHandlebarsViewResolver.setFailOnMissingFile(false);
+      View view = parameterizedHandlebarsViewResolver.resolveViewName("invalidView", Locale.getDefault());
+      assertNull(view);
+    } finally {
+      parameterizedHandlebarsViewResolver.setFailOnMissingFile(true);
+    }
+  }
+
   @Test(expected = IOException.class)
   public void failToResolve() throws Exception {
     try {
@@ -64,6 +88,17 @@ public class HandlebarsViewResolverIntegrationTest {
       viewResolver.resolveViewName("invalidView", Locale.getDefault());
     } finally {
       viewResolver.setFailOnMissingFile(true);
+    }
+  }
+
+  @Test(expected = IOException.class)
+  public void failToResolveParameterized() throws Exception {
+    try {
+      assertNotNull(parameterizedHandlebarsViewResolver);
+      parameterizedHandlebarsViewResolver.setFailOnMissingFile(true);
+      parameterizedHandlebarsViewResolver.resolveViewName("invalidView", Locale.getDefault());
+    } finally {
+      parameterizedHandlebarsViewResolver.setFailOnMissingFile(true);
     }
   }
 


### PR DESCRIPTION
Added the ability to instantiate the `HandlebarsViewResolver` with a pre-instantiated `Handlebars` object. This allows flexibility without the need for brittle inheritance, especially when trying to use custom `TemplateLoaders` that are not of type `URLTemplateLoader`.