### PR TITLE
Getting optimization level from a system property

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
@@ -79,9 +79,12 @@ public class DefaultHelperRegistry implements HelperRegistry {
   /**
    * A Handlebars.js implementation.
    */
-  private HandlebarsJs handlebarsJs = HandlebarsJs.create(this);
+  private HandlebarsJs handlebarsJs;
 
   {
+    Integer optimizationLevel = Integer.valueOf(Integer.parseInt(
+                System.getProperty("handlebars.rhino.optmizationLevel", "-1")));
+    this.handlebarsJs = HandlebarsJs.createRhino(this, optimizationLevel);
     // make sure default helpers are registered
     registerBuiltinsHelpers(this);
   }


### PR DESCRIPTION
With this PR, it's possible to override the hardcoded optimization level of Rhino (which currently is -1) with a java property, `handlebars.rhino.optmizationLevel`

What do you think?