### PR TITLE
Update URLTemplateSource.java make reader protected

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/io/URLTemplateSource.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/io/URLTemplateSource.java
@@ -106,7 +106,7 @@ public class URLTemplateSource extends AbstractTemplateSource {
    * @return A reader.
    * @throws IOException If the stream can't be opened.
    */
-  private Reader reader() throws IOException {
+  protected Reader reader() throws IOException {
     InputStream in = resource.openStream();
     return new InputStreamReader(in, "UTF-8");
   }


### PR DESCRIPTION
I like this class, except i want to send some custom request headers to get my remote templates (test segments, accept header, etc).  making this protected would allow me to tweak the input stream that gets thrown through the buffer.  as it is now i have to reimplement most the code to do this.