### PR TITLE
Support basic methods in TypeSafeTemplate proxy (toString, hashCode, equals)

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
@@ -253,19 +253,17 @@ abstract class BaseTemplate implements Template {
    * @return A new {@link TypeSafeTemplate}.
    */
   private static Object newTypeSafeTemplate(final Class<?> rootType, final Template template) {
-    return Proxy.newProxyInstance(rootType.getClassLoader(), new Class[]{ rootType },
+    return Proxy.newProxyInstance(rootType.getClassLoader(), new Class[]{rootType },
         new InvocationHandler() {
 
           private final Map<String, Object> attributes = new HashMap<>();
-          private final Object[] NO_ARGS = {};
+          private final Object[] emptyArgs = {};
 
           @Override
-          public Object invoke(final Object proxy, final Method method, Object[] args)
+          public Object invoke(final Object proxy, final Method method, final Object[] methodArgs)
               throws IOException {
 
-            if (args == null) {
-              args = NO_ARGS;
-            }
+            Object[] args = methodArgs == null ? emptyArgs : methodArgs;
 
             String methodName = method.getName();
 

--- a/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
@@ -1,6 +1,10 @@
 package com.github.jknack.handlebars;
 
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 
@@ -35,7 +39,6 @@ public class TypeSafeTemplateTest extends AbstractTest {
     User user = new User("edgar");
     TypeSafeTemplate<User> userTemplate = compile("Hello {{name}}!").as();
     assertEquals("Hello edgar!", userTemplate.apply(user));
-
   }
 
   @Test
@@ -58,6 +61,31 @@ public class TypeSafeTemplateTest extends AbstractTest {
         .setRole("Software Architect");
 
     assertEquals("Software Architect", userTemplate.apply(user));
+  }
+
+  @Test
+  public void testToString() throws IOException {
+    UserTemplate userTemplate = compile("Hello {{name}}").as(UserTemplate.class);
+    assertThat(userTemplate.toString(), containsString("UserTemplate"));
+  }
+
+  @Test
+  public void testHashCode() throws IOException {
+    Template template = compile("Hello {{name}}");
+    UserTemplate userTemplate = template.as(UserTemplate.class);
+
+    assertEquals(userTemplate.hashCode(), userTemplate.hashCode());
+    assertNotEquals(userTemplate.hashCode(), template.as(UserTemplate.class));
+  }
+
+  @Test
+  public void testEquals() throws IOException {
+    Template template = compile("Hello {{name}}");
+    UserTemplate userTemplate = template.as(UserTemplate.class);
+
+    assertEquals(userTemplate, userTemplate);
+    assertNotEquals(userTemplate, template.as(UserTemplate.class));
+    assertFalse(userTemplate.equals(null));
   }
 
   @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
Add basic implementations for toString, hashCode, and equals to the invocation
handler for the TypeSafeTemplate proxy.

- toString returns "TypeSafeTemplateProxy{interface=InterfaceName}"
- hashCode returns the hash code of the InvocationHandler instance
- equals performs a basic identity based comparison to the proxy instance

Resolves #514 