### PR TITLE
Added support for IETF language tags in helpers

### DIFF
--- a/handlebars-humanize/src/main/java/com/github/jknack/handlebars/HumanizeHelper.java
+++ b/handlebars-humanize/src/main/java/com/github/jknack/handlebars/HumanizeHelper.java
@@ -27,6 +27,8 @@ import java.util.Locale;
 
 import org.apache.commons.lang3.LocaleUtils;
 
+import com.github.jknack.handlebars.internal.Locales;
+
 /**
  * Handlebars helper for the Humanize library.
  *
@@ -467,7 +469,7 @@ public enum HumanizeHelper implements Helper<Object> {
    */
   protected static Locale resolveLocale(final Options options) {
     String locale = options.hash("locale", Locale.getDefault().toString());
-    return LocaleUtils.toLocale(locale);
+    return Locales.fromString(locale);
   }
 
   /**

--- a/handlebars-humanize/src/main/java/com/github/jknack/handlebars/HumanizeHelper.java
+++ b/handlebars-humanize/src/main/java/com/github/jknack/handlebars/HumanizeHelper.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Locale;
 
-import org.apache.commons.lang3.LocaleUtils;
-
 import com.github.jknack.handlebars.internal.Locales;
 
 /**

--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/I18nHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/I18nHelper.java
@@ -32,8 +32,6 @@ import java.util.ResourceBundle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.LocaleUtils;
-
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/I18nHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/I18nHelper.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.LocaleUtils;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.internal.Locales;
 
 /**
  * Implementation of i18n helper for Java and JavaScript.
@@ -154,8 +155,8 @@ public enum I18nHelper implements Helper<String> {
     @Override
     public Object apply(final String key, final Options options) throws IOException {
       notEmpty(key, "found: '%s', expected 'bundle's key'", key);
-      Locale locale = LocaleUtils
-          .toLocale((String) options.hash("locale", defaultLocale.toString()));
+      Locale locale = Locales
+          .fromString((String) options.hash("locale", defaultLocale.toString()));
       String baseName = options.hash("bundle", defaultBundle);
       ClassLoader classLoader = options.hash("classLoader", getClass().getClassLoader());
       I18nSource localSource = source == null
@@ -229,7 +230,7 @@ public enum I18nHelper implements Helper<String> {
      */
     @Override
     public Object apply(final String localeName, final Options options) throws IOException {
-      Locale locale = LocaleUtils.toLocale(defaultIfEmpty(localeName, defaultLocale.toString()));
+      Locale locale = Locales.fromString(defaultIfEmpty(localeName, defaultLocale.toString()));
       String baseName = options.hash("bundle", defaultBundle);
       ClassLoader classLoader = options.hash("classLoader", getClass().getClassLoader());
       I18nSource localSource = source == null

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Locales.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Locales.java
@@ -1,0 +1,43 @@
+package com.github.jknack.handlebars.internal;
+
+import java.util.IllformedLocaleException;
+import java.util.Locale;
+
+import org.apache.commons.lang3.LocaleUtils;
+
+/**
+ * Utility methods to resolve {@link Locale}s from Strings.
+ *
+ */
+public final class Locales {
+
+  private Locales() {
+  }
+
+  /**
+   * <p>Converts {@link String}s to {@link Locale}s. Supports both 
+   * <a href="https://en.wikipedia.org/wiki/IETF_language_tag">IETF language tags</a> 
+   * using hyphens (e.g. &quot;de-AT&quot;) and the Java format using underscores (e.g. &quot;de_AT&quot;).</p>
+   * 
+   * 
+   * @param string, either in IETF or Java format (hyphen or underscore)
+   * @return locale
+   */
+  public static final Locale fromString(String string) {
+    if (string == null) {
+      return null;
+    } else {
+      try {
+        /*
+         *  prefer https://en.wikipedia.org/wiki/IETF_language_tag
+         *  (only Locale.Builder throws exception for illegal format)
+         */
+        return new Locale.Builder().setLanguageTag(string).build();
+      } catch (final IllformedLocaleException ex) {
+        // use fallback
+        return LocaleUtils.toLocale(string);
+      }
+    }
+  }
+
+}

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Locales.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Locales.java
@@ -11,19 +11,22 @@ import org.apache.commons.lang3.LocaleUtils;
  */
 public final class Locales {
 
+  /**
+   * Not allowed.
+   */
   private Locales() {
   }
 
   /**
-   * <p>Converts {@link String}s to {@link Locale}s. Supports both 
-   * <a href="https://en.wikipedia.org/wiki/IETF_language_tag">IETF language tags</a> 
-   * using hyphens (e.g. &quot;de-AT&quot;) and the Java format using underscores (e.g. &quot;de_AT&quot;).</p>
-   * 
-   * 
-   * @param string, either in IETF or Java format (hyphen or underscore)
-   * @return locale
+   * <p>Converts {@link String}s to {@link Locale}s. Supports both
+   * <a href="https://en.wikipedia.org/wiki/IETF_language_tag">IETF language tags</a>
+   * using hyphens (e.g. &quot;de-AT&quot;) and the Java format using underscores
+   * (e.g. &quot;de_AT&quot;).</p>
+   *
+   * @param string the local string either in IETF or Java format
+   * @return The matching Locale
    */
-  public static final Locale fromString(String string) {
+  public static Locale fromString(final String string) {
     if (string == null) {
       return null;
     } else {

--- a/handlebars/src/test/java/com/github/jknack/handlebars/internal/LocalesTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/internal/LocalesTest.java
@@ -1,5 +1,6 @@
 package com.github.jknack.handlebars.internal;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +29,11 @@ public class LocalesTest {
       // l.toLanguageTag() returns format de-DE
       assertEquals(l, Locales.fromString(l.toLanguageTag()));
     }
+  }
+
+  @Test
+  public void testNull() {
+     assertNull(Locales.fromString(null));
   }
 
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/internal/LocalesTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/internal/LocalesTest.java
@@ -1,0 +1,33 @@
+package com.github.jknack.handlebars.internal;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link Locales}.
+ */
+public class LocalesTest {
+
+  private static List<Locale> COMMON_LOCALES = Arrays.asList(Locale.CANADA, Locale.CANADA_FRENCH, Locale.CHINA, Locale.ENGLISH, Locale.GERMANY, Locale.FRANCE);
+
+  @Test
+  public void testUnderscore() {
+    for (Locale l : COMMON_LOCALES) {
+      // l.toString() returns format de_DE
+      assertEquals(l, Locales.fromString(l.toString()));
+    }
+  }
+
+  @Test
+  public void testHyphen() {
+    for (Locale l : COMMON_LOCALES) {
+      // l.toLanguageTag() returns format de-DE
+      assertEquals(l, Locales.fromString(l.toLanguageTag()));
+    }
+  }
+
+}


### PR DESCRIPTION
The used method to get from locale strings to Locale objects only
supported java-style Locales using an underscore (e.g. "de_DE"), the
preferred way however is using the IETF language tag
(https://en.wikipedia.org/wiki/IETF_language_tag). In order to enable
users to use IETF language tags in their templates, support has been
added.

This is fully backwards compatible as the previous way to get the
locale has been left as fallback.