### PR TITLE
Invoke default methods on Type Safe template interfaces

### DIFF
--- a/handlebars-jdk8-tests/pom.xml
+++ b/handlebars-jdk8-tests/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>handlebars.java</artifactId>
+    <groupId>com.github.jknack</groupId>
+    <version>4.0.6-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jdk8-tests</artifactId>
+
+  <name>Handlebars.java - JDK8 Tests</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.jknack</groupId>
+      <artifactId>handlebars</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration combine.self="override" />
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/handlebars-jdk8-tests/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateDefaultMethodTest.java
+++ b/handlebars-jdk8-tests/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateDefaultMethodTest.java
@@ -1,0 +1,37 @@
+package com.github.jknack.handlebars;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.Test;
+
+public class TypeSafeTemplateDefaultMethodTest {
+
+    private static class User {
+        private final String name;
+
+        User(final String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    interface UserTemplate extends TypeSafeTemplate<User> {
+        default String renderUpperCase(User user) throws IOException {
+            return apply(user).toUpperCase();
+        }
+    }
+
+    @Test
+    public void testDefaultMethod() throws Exception {
+        User user = new User("Smitty");
+        UserTemplate template = new Handlebars()
+                .compileInline("Hello {{name}}")
+                .as(UserTemplate.class);
+        String result = template.renderUpperCase(user);
+        assertEquals("HELLO SMITTY", result);
+    }
+}

--- a/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
@@ -34,6 +34,10 @@ public class TypeSafeTemplateTest extends AbstractTest {
     public void set(int v);
   }
 
+  private static TypeSafeTemplate<User> createTemplate() {
+      return null;
+  }
+
   @Test
   public void genericTypeSafe() throws IOException {
     User user = new User("edgar");

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <module>handlebars-guava-cache</module>
     <module>handlebars-maven-plugin</module>
     <module>handlebars-maven-plugin-tests</module>
-    <module>handlebars-jdk8-tests</module>
     <module>integration-tests</module>
   </modules>
 
@@ -330,6 +329,26 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>jdk8</id>
+      <modules>
+          <module>handlebars</module>
+          <module>handlebars-helpers</module>
+          <module>handlebars-springmvc</module>
+          <module>handlebars-jackson2</module>
+          <module>handlebars-markdown</module>
+          <module>handlebars-humanize</module>
+          <module>handlebars-proto</module>
+          <module>handlebars-guava-cache</module>
+          <module>handlebars-maven-plugin</module>
+          <module>handlebars-maven-plugin-tests</module>
+          <module>integration-tests</module>
+          <module>handlebars-jdk8-tests</module>
+      </modules>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+    </profile>
     <profile>
       <id>bench</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <module>handlebars-guava-cache</module>
     <module>handlebars-maven-plugin</module>
     <module>handlebars-maven-plugin-tests</module>
+    <module>handlebars-jdk8-tests</module>
     <module>integration-tests</module>
   </modules>
 


### PR DESCRIPTION
This resolves #515. I am a bit unsure how to include a test for this, since the source/target Java versions are set to 7 in the pom.xml. Maybe using Animal Sniffer?