### PR TITLE
Rename setHelpers(List) to setHelperSources to remove ambiguity

### DIFF
--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -399,7 +399,7 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
    * @see Handlebars#registerHelpers(Class)
    * @see Handlebars#registerHelpers(Object)
    */
-  public void setHelpers(final List<Object> helpers) {
+  public void setHelperSources(final List<?> helpers) {
     notNull(helpers, "The helpers are required.");
     for (Object helper : helpers) {
       registry.registerHelpers(helper);

--- a/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsApp.java
+++ b/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsApp.java
@@ -1,6 +1,7 @@
 package com.github.jknack.handlebars.springmvc;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +32,9 @@ public class HandlebarsApp {
         return "Spring Helper";
       }
     };
+
     viewResolver.registerHelper("spring", helper);
-    viewResolver.registerHelpers(HandlebarsApp.class);
+    viewResolver.setHelperSources(Arrays.asList(HandlebarsApp.class));
     Map<String, Helper<?>> helpers = new HashMap<String, Helper<?>>();
     helpers.put("setHelper", helper);
     viewResolver.setHelpers(helpers);


### PR DESCRIPTION
It was impossible to set helper sources using spring xml based configuration. It considered setHelpers(java.util.List) and setHelpers(java.util.Map) to be ambiguous, and would try to convert a
list of helper sources to a map.

Fixes #535 