### PR TITLE
Update docs about reusing through inheritance

### DIFF
--- a/reuse.html
+++ b/reuse.html
@@ -71,7 +71,7 @@ Output:
 
 <li><strong>template inheritance</strong>
 <p>
-Template inheritance can be done with <code>inline partial decorator</code>.
+Template inheritance can be done with <code>block/partial syntax</code>.
 </p>
 
 <div style="float: right;">Support by:
@@ -84,16 +84,16 @@ base.hbs:
 
 <div class="highlight">
 <pre>
-{{ "{{#> header" }}}}
+{{ "{{#block &quot;header&quot;" }}}}
 <span class="nt">&lt;h1&gt;</span>Title<span class="nt">&lt;/h1&gt;</span>
-{{ "{{/header" }}}}
+{{ "{{/block" }}}}
 
-{{ "{{#> content" }}}}
-{{ "{{/content" }}}}
+{{ "{{#block &quot;content&quot;" }}}}
+{{ "{{/block" }}}}
 
-{{ "{{#> &quot;footer&quot; " }}}}
+{{ "{{#block &quot;footer&quot; " }}}}
 <span class="nt">&lt;span&gt;</span>Powered by Handlebars.java<span class="nt">&lt;/span&gt;</span>
-{{ "{{/footer" }}}}
+{{ "{{/block" }}}}
 </pre>
 </div>
 
@@ -103,9 +103,9 @@ home.hbs:
 
 <div class="highlight">
 <pre>
-{{ "{{#*inline content " }}}}
+{{ "{{#partial &quot;content&quot; " }}}}
 <span class="nt">&lt;p&gt;</span>Home page<span class="nt">&lt;/p&gt;</span>
-{{ "{{/inline" }}}}
+{{ "{{/partial" }}}}
 
 {{ "{{> base" }}}}
 </pre>

--- a/reuse.html
+++ b/reuse.html
@@ -123,7 +123,7 @@ Output:
 </pre>
 </div>
 <p>The <code>header</code> and <code>footer</code> names represent the name of a template (or
-partial) that need to be loaded. If these templates don't exist, the helper body is used.</p>
+partial) that need to be loaded. If these templates don't exist, the original block body is used.</p>
 <p>In the example above <code>header</code> and <code>footer</code> don't exist, that is why we get
 the default content of each of this partials.</p>
 <p>You can find more information <a href="http://thejohnfreeman.com/blog/2012/03/23/template-inheritance-for-handlebars.html">here</a></p>

--- a/reuse.html
+++ b/reuse.html
@@ -122,10 +122,5 @@ Output:
 <span class="nt">&lt;span&gt;</span>Powered by Handlebars.java<span class="nt">&lt;/span&gt;</span>
 </pre>
 </div>
-<p>The <code>header</code> and <code>footer</code> names represent the name of a template (or
-partial) that need to be loaded. If these templates don't exist, the original block body is used.</p>
-<p>In the example above <code>header</code> and <code>footer</code> don't exist, that is why we get
-the default content of each of this partials.</p>
-<p>You can find more information <a href="http://thejohnfreeman.com/blog/2012/03/23/template-inheritance-for-handlebars.html">here</a></p>
 </li>
 </ul>


### PR DESCRIPTION
The syntax that actually work with handlebars java 4.0.6 is block/partials.
It didn't worked with the inline partial decorator syntax.