### PR TITLE
Add missing keys on context of EachHelper

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/EachHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/EachHelper.java
@@ -62,7 +62,8 @@ public class EachHelper implements Helper<Object> {
       while (loop.hasNext()) {
         Object it = loop.next();
         Context itCtx = Context.newContext(parent, it);
-        itCtx.combine("@index", index)
+        itCtx.combine("@key", index)
+            .combine("@index", index)
             .combine("@first", index == base ? "first" : "")
             .combine("@last", !loop.hasNext() ? "last" : "")
             .combine("@odd", even ? "" : "odd")
@@ -79,6 +80,7 @@ public class EachHelper implements Helper<Object> {
       }
       return buffer;
     } else if (context != null) {
+      int index = 0;
       Iterator loop = options.propertySet(context).iterator();
       Context parent = options.context;
       boolean first = true;
@@ -90,11 +92,13 @@ public class EachHelper implements Helper<Object> {
         Object value = entry.getValue();
         Context itCtx = Context.newBuilder(parent, value)
             .combine("@key", key)
+            .combine("@index", index)
             .combine("@first", first ? "first" : "")
             .combine("@last", !loop.hasNext() ? "last" : "")
             .build();
         buffer.append(options.apply(fn, itCtx, Arrays.asList(value, key)));
         first = false;
+        index++;
       }
       // empty?
       if (first) {


### PR DESCRIPTION
Add @key to Iterable and @index to Map as in handlebars.js, where iterables and maps use the same helper function `execIteration` (https://github.com/wycats/handlebars.js/blob/master/lib/handlebars/helpers/each.js) (2016-09-27).

line 22:
```js
    function execIteration(field, index, last) {
      if (data) {
        data.key = field;
        data.index = index;
        data.first = index === 0;
        data.last = !!last;
      }

      ret = ret + fn(context[field], {
        data: data,
        blockParams: [context[field], field]
      });
    }
```

line 36:
```
 if (context && typeof context === 'object') {
      if (isArray(context)) {
        for (let j = context.length; i < j; i++) {
          if (i in context) {
            execIteration(i, i, i === context.length - 1);
          }
        }
      } else {
        let priorKey;

        for (let key in context) {
          if (context.hasOwnProperty(key)) {
            // 3 lines of comments....
            if (priorKey !== undefined) {
              execIteration(priorKey, i - 1);
            }
            priorKey = key;
            i++;
          }
        }
        if (priorKey !== undefined) {
          execIteration(priorKey, i - 1, true);
        }
      }
    }
```