### PR TITLE
switch helper replacement to info level

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
@@ -103,7 +103,7 @@ public class DefaultHelperRegistry implements HelperRegistry {
 
     Helper<?> oldHelper = helpers.put(name, helper);
     if (oldHelper != null) {
-      logger.warn("Helper '{}' has been replaced by '{}'", name, helper);
+      logger.info("Helper '{}' has been replaced by '{}'", name, helper);
     }
     return this;
   }


### PR DESCRIPTION
i think most decent org log at the warn level (or higher)...we get a ton of this warning, like millions of lines of it.  seems like it's not really bad behaviour that needs to be warned about.  Seems like an info event.  Seems like this shoudl only be warn if something is actually being done incorrectly.  is that the case?  what's the "correct" way then?