### PR TITLE
fixed JsonNodeValueResolver

### DIFF
--- a/handlebars-jackson2/src/main/java/com/github/jknack/handlebars/JsonNodeValueResolver.java
+++ b/handlebars-jackson2/src/main/java/com/github/jknack/handlebars/JsonNodeValueResolver.java
@@ -65,7 +65,10 @@ public enum JsonNodeValueResolver implements ValueResolver {
       }
     } else if (context instanceof JsonNode) {
       value = resolve(((JsonNode) context).get(name));
+    } else if (context instanceof AbstractMap) {
+      value = ((AbstractMap) context).get(name);
     }
+
     return value == null ? UNRESOLVED : value;
   }
 


### PR DESCRIPTION
During the resolving phase, if toMap was called, an object of AbstractMap will be created.
If we have multiple levels of resolving, then at next level, we will be resolving an AbstractMap, not ArrayNode or JsonNode. The existing code doesn't handle this properly and the resolved value will be set to null.

For example, if I have a Java Object which has a HashMap called map containing two tuples
"a": "aaa"
"b": "bbb"

Wasn't able to access {{map.a}}, as during the resolving, map yields the AbstractMap.