### PR TITLE
Fix: The context can now be manipulated when in a partial

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/HelperResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/HelperResolver.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Map.Entry;
 
 import com.github.jknack.handlebars.Context;
@@ -80,8 +81,8 @@ abstract class HelperResolver extends BaseTemplate {
    * @throws IOException If param can't be applied.
    */
   protected Map<String, Object> hash(final Context context) throws IOException {
-    if (hashSize == 0) {
-      return Collections.emptyMap();
+    if (hashSize == 0) {      
+      return new HashMap<>();
     }
     Map<String, Object> result = new LinkedHashMap<String, Object>();
     for (Entry<String, Param> entry : hash.entrySet()) {

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/HelperResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/HelperResolver.java
@@ -81,7 +81,7 @@ abstract class HelperResolver extends BaseTemplate {
    * @throws IOException If param can't be applied.
    */
   protected Map<String, Object> hash(final Context context) throws IOException {
-    if (hashSize == 0) {      
+    if (hashSize == 0) {
       return new HashMap<>();
     }
     Map<String, Object> result = new LinkedHashMap<String, Object>();

--- a/handlebars/src/test/java/com/github/jknack/handlebars/WriteIntoContextTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/WriteIntoContextTest.java
@@ -1,0 +1,39 @@
+package com.github.jknack.handlebars;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class WriteIntoContextTest extends AbstractTest {
+    protected void configure(final Handlebars handlebars) {
+        handlebars.registerHelpers(new WriteIntoContextTest.SetHelperClass());
+    }
+
+    @Test
+    public void shouldBeAbleToWriteIntoContext() throws IOException {
+        shouldCompileTo("{{set \"foo\" this}}{{foo}}", "bar", "bar");
+    }
+
+    @Test
+    public void shouldBeAbleToWriteIntoContextWhenInBlockHelper() throws IOException {
+        shouldCompileTo("{{#with data}}{{set \"foo\" field}}{{foo}}{{/with}}", "{\"data\" : {\"field\": \"bar\"}}", "bar");
+    }
+
+    @Test
+    public void shouldBeAbleToWriteIntoContextWhenInPartial() throws IOException {
+        shouldCompileToWithPartials("{{> partial}}", "bar",
+                constructPartials("partial", "{{set \"foo\" this}}{{foo}}"),
+                "bar");
+    }
+
+    private Hash constructPartials(String name, String content) throws IOException {
+        return new Hash().$(name, content);
+    }
+
+    public static class SetHelperClass {
+        public String set(String key, Object value, Options options) throws NoSuchFieldException {
+            options.context.combine(key, value);
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
This issue arose after upgrading from 4.0.4 to 4.0.6. The attached tests explains it clearly. The context could no longer be manipulated (context.combine()) when inside of a partial, because the attached map was an empty stub (Collections.emptyMap()).
This has been solved.