### PR TITLE
ClassPathTemplateLoader add getClassLoader()

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/io/ClassPathTemplateLoader.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/io/ClassPathTemplateLoader.java
@@ -60,6 +60,6 @@ public class ClassPathTemplateLoader extends URLTemplateLoader {
 
   @Override
   protected URL getResource(final String location) {
-    return  getClass().getResource(location);
+    return  getClass().getClassLoader().getResource(location);
   }
 }


### PR DESCRIPTION
The getClass().getResource() will load resources relative to the classes path.

This will confuse people when reading the documentation and trying to load Templates and running unit tests which will not work without a starting "/" in the TemplateLoader prefix.

Either this change, or checking for both first and last "/" in prefix when normalizing the location for this TemplateLoader.