### PR TITLE
Fixing tiny documentation issue with upper function

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/StringHelpers.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/StringHelpers.java
@@ -284,7 +284,7 @@ public enum StringHelpers implements Helper<Object> {
   },
 
   /**
-   * Converts a string into all lowercase.
+   * Converts a string into all uppercase.
    * For example:
    *
    * <pre>


### PR DESCRIPTION
The java doc for upper states it lowercases it, when it should say it uppercases it.