### PR TITLE
Massive performance improvement

### DIFF
--- a/handlebars/pom.xml
+++ b/handlebars/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.github.jknack</groupId>
     <artifactId>handlebars.java</artifactId>
-    <version>4.0.7-SNAPSHOT</version>
+    <version>4.0.8-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
@@ -1,24 +1,23 @@
 /**
  * Copyright (c) 2012-2015 Edgar Espina
  *
- * This file is part of Handlebars.java.
+ * <p>This file is part of Handlebars.java.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package com.github.jknack.handlebars;
 
-import static org.apache.commons.lang3.Validate.notEmpty;
-
+import com.github.jknack.handlebars.internal.path.PropertyPath;
+import com.github.jknack.handlebars.internal.path.ThisPath;
+import com.github.jknack.handlebars.io.TemplateSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,12 +29,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.github.jknack.handlebars.internal.path.ThisPath;
-import com.github.jknack.handlebars.io.TemplateSource;
+import static org.apache.commons.lang3.Validate.notEmpty;
 
 /**
- * Mustache/Handlebars are contextual template engines. This class represent the
- * 'context stack' of a template.
+ * Mustache/Handlebars are contextual template engines. This class represent the 'context stack' of
+ * a template.
+ *
  * <ul>
  * <li>Objects and hashes should be pushed onto the context stack.
  * <li>All elements on the context stack should be accessible.
@@ -44,7 +43,7 @@ import com.github.jknack.handlebars.io.TemplateSource;
  * <li>Dotted names should be valid for Section tags.
  * <li>Dotted names that cannot be resolved should be considered falsy.
  * <li>Dotted Names - Context Precedence: Dotted names should be resolved against former
- * resolutions.
+ *     resolutions.
  * </ul>
  *
  * @author edgar.espina
@@ -176,9 +175,7 @@ public class Context {
    */
   private static class CompositeValueResolver implements ValueResolver {
 
-    /**
-     * The internal value resolvers.
-     */
+    /** The internal value resolvers. */
     private ValueResolver[] resolvers;
 
     /**
@@ -234,9 +231,7 @@ public class Context {
    */
   public static final class Builder {
 
-    /**
-     * The context product.
-     */
+    /** The context product. */
     private Context context;
 
     /**
@@ -295,8 +290,8 @@ public class Context {
     }
 
     /**
-     * Add one or more value resolver to the defaults defined by
-     * {@link ValueResolver#VALUE_RESOLVERS}.
+     * Add one or more value resolver to the defaults defined by {@link
+     * ValueResolver#VALUE_RESOLVERS}.
      *
      * @param resolvers The value resolvers. Required.
      * @return This builder.
@@ -374,57 +369,36 @@ public class Context {
       }
       return value;
     }
-
   }
 
-  /**
-   * Mark for fail context lookup.
-   */
+  /** Mark for fail context lookup. */
   private static final Object NULL = new Object();
 
-  /**
-   * The qualified name for partials. Internal use.
-   */
+  /** The qualified name for partials. Internal use. */
   public static final String PARTIALS = Context.class.getName() + "#partials";
 
-  /**
-   * Inline partials.
-   */
+  /** Inline partials. */
   public static final String INLINE_PARTIALS = "__inline_partials_";
 
-  /**
-   * The qualified name for partials. Internal use.
-   */
+  /** The qualified name for partials. Internal use. */
   public static final String INVOCATION_STACK = Context.class.getName() + "#invocationStack";
 
-  /**
-   * Number of parameters of a helper. Internal use.
-   */
+  /** Number of parameters of a helper. Internal use. */
   public static final String PARAM_SIZE = Context.class.getName() + "#paramSize";
 
-  /**
-   * The parent context. Optional.
-   */
+  /** The parent context. Optional. */
   protected Context parent;
 
-  /**
-   * The target value. Resolved as '.' or 'this' inside templates. Required.
-   */
+  /** The target value. Resolved as '.' or 'this' inside templates. Required. */
   Object model;
 
-  /**
-   * A thread safe storage.
-   */
+  /** A thread safe storage. */
   protected Map<String, Object> data;
 
-  /**
-   * Additional, data can be stored here.
-   */
+  /** Additional, data can be stored here. */
   protected Context extendedContext;
 
-  /**
-   * The value resolver.
-   */
+  /** The value resolver. */
   protected ValueResolver resolver;
 
   /**
@@ -441,8 +415,7 @@ public class Context {
   /**
    * Creates a root context.
    *
-   * @param model The target value. Resolved as '.' or 'this' inside
-   *        templates. Required.
+   * @param model The target value. Resolved as '.' or 'this' inside templates. Required.
    * @return A root context.
    */
   private static Context root(final Object model) {
@@ -465,7 +438,7 @@ public class Context {
    * @param model The model data.
    * @return This context.
    */
-  @SuppressWarnings({"unchecked" })
+  @SuppressWarnings({"unchecked"})
   public Context combine(final String name, final Object model) {
     Map<String, Object> map = (Map<String, Object>) extendedContext.model;
     map.put(name, model);
@@ -478,7 +451,7 @@ public class Context {
    * @param model The model attributes.
    * @return This context.
    */
-  @SuppressWarnings({"unchecked" })
+  @SuppressWarnings({"unchecked"})
   public Context combine(final Map<String, ?> model) {
     Map<String, Object> map = (Map<String, Object>) extendedContext.model;
     map.putAll(model);
@@ -563,15 +536,14 @@ public class Context {
     return propertySet(model);
   }
 
-  /**
-   * @return True, if this context is a block param context.
-   */
+  /** @return True, if this context is a block param context. */
   public boolean isBlockParams() {
     return this instanceof BlockParam;
   }
 
   /**
    * Lookup the given key inside the context stack.
+   *
    * <ul>
    * <li>Objects and hashes should be pushed onto the context stack.
    * <li>All elements on the context stack should be accessible.
@@ -580,7 +552,7 @@ public class Context {
    * <li>Dotted names should be valid for Section tags.
    * <li>Dotted names that cannot be resolved should be considered falsey.
    * <li>Dotted Names - Context Precedence: Dotted names should be resolved against former
-   * resolutions.
+   *     resolutions.
    * </ul>
    *
    * @param path The object path.
@@ -603,7 +575,9 @@ public class Context {
         value = expr.eval(resolver, it, it.model);
         if (value == null) {
           // No luck, check the extended context.
-          value = expr.eval(resolver, it.extendedContext, it.extendedContext.model);
+          if (!(head instanceof PropertyPath)) {
+            value = expr.eval(resolver, it.extendedContext, it.extendedContext.model);
+          }
 
           if (value == null) {
             // data context
@@ -618,6 +592,7 @@ public class Context {
 
   /**
    * Lookup the given key inside the context stack.
+   *
    * <ul>
    * <li>Objects and hashes should be pushed onto the context stack.
    * <li>All elements on the context stack should be accessible.
@@ -626,7 +601,7 @@ public class Context {
    * <li>Dotted names should be valid for Section tags.
    * <li>Dotted names that cannot be resolved should be considered falsey.
    * <li>Dotted Names - Context Precedence: Dotted names should be resolved against former
-   * resolutions.
+   *     resolutions.
    * </ul>
    *
    * @param key The object key.
@@ -638,6 +613,7 @@ public class Context {
 
   /**
    * Lookup the given key inside the context stack.
+   *
    * <ul>
    * <li>Objects and hashes should be pushed onto the context stack.
    * <li>All elements on the context stack should be accessible.
@@ -646,7 +622,7 @@ public class Context {
    * <li>Dotted names should be valid for Section tags.
    * <li>Dotted names that cannot be resolved should be considered falsey.
    * <li>Dotted Names - Context Precedence: Dotted names should be resolved against former
-   * resolutions.
+   *     resolutions.
    * </ul>
    *
    * @param key The object key.
@@ -667,9 +643,7 @@ public class Context {
     extendedContext.resolver = resolver;
   }
 
-  /**
-   * Destroy this context by cleaning up instance attributes.
-   */
+  /** Destroy this context by cleaning up instance attributes. */
   public void destroy() {
     model = null;
     if (parent == null) {
@@ -731,8 +705,8 @@ public class Context {
    * @param values A list of values to set in the block param context.
    * @return A new block param context.
    */
-  public static Context newBlockParamContext(final Context parent, final List<String> names,
-      final List<Object> values) {
+  public static Context newBlockParamContext(
+      final Context parent, final List<String> names, final List<Object> values) {
     Map<String, Object> hash = new HashMap<String, Object>();
     for (int i = 0; i < Math.min(values.size(), names.size()); i++) {
       hash.put(names.get(i), values.get(i));
@@ -748,8 +722,8 @@ public class Context {
    * @param hash Partial hash.
    * @return A new context.
    */
-  public static Context newPartialContext(final Context ctx, final String scope,
-      final Map<String, Object> hash) {
+  public static Context newPartialContext(
+      final Context ctx, final String scope, final Map<String, Object> hash) {
     return new PartialCtx(ctx, ctx.get(scope), hash);
   }
 
@@ -801,5 +775,4 @@ public class Context {
     ctx.resolver = context.resolver;
     return ctx;
   }
-
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
@@ -15,7 +15,8 @@
  */
 package com.github.jknack.handlebars;
 
-import com.github.jknack.handlebars.internal.path.PropertyPath;
+import static org.apache.commons.lang3.Validate.notEmpty;
+
 import com.github.jknack.handlebars.internal.path.ThisPath;
 import com.github.jknack.handlebars.io.TemplateSource;
 import java.util.ArrayList;
@@ -28,8 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import static org.apache.commons.lang3.Validate.notEmpty;
 
 /**
  * Mustache/Handlebars are contextual template engines. This class represent the 'context stack' of
@@ -575,9 +574,7 @@ public class Context {
         value = expr.eval(resolver, it, it.model);
         if (value == null) {
           // No luck, check the extended context.
-          if (!(head instanceof PropertyPath)) {
-            value = expr.eval(resolver, it.extendedContext, it.extendedContext.model);
-          }
+          value = expr.eval(resolver, it.extendedContext, it.extendedContext.model);
 
           if (value == null) {
             // data context

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -282,8 +282,10 @@ public class Handlebars implements HelperRegistry {
   private boolean deletePartialAfterMerge;
 
   /**
-   * If true partial blocks will be evaluated to allow side effects by defining inline blocks within the partials blocks.
-   * Attention: This feature slows down the performance severly if your templates use deeply nested partial blocks.
+   * If true partial blocks will be evaluated to allow side effects by defining inline
+   * blocks within the partials blocks.
+   * Attention: This feature slows down the performance severly if your templates use
+   * deeply nested partial blocks.
    * Handlebars works *much* faster if this feature is set to false.
    *
    * Example of a feature that is usable when this is set to true:
@@ -853,30 +855,37 @@ public class Handlebars implements HelperRegistry {
   }
 
   /**
-   * If true, partial blocks will implicitly be evaluated before the partials will actually be executed.
-   * If false, you need to explicitly evaluate and render partial blocks with
+   * If true, partial blocks will implicitly be evaluated before the partials will actually
+   * be executed. If false, you need to explicitly evaluate and render partial blocks with
    * <pre>
    *     {{> @partial-block}}
    * </pre>
    * Attention: If this is set to true, Handlebars works *much* slower!
    *
-   * @return If true partial blocks will be evaluated before the partial will be rendered to allow inline block side effects.
-   *         If false, you will have to evaluate and render partial blocks explitly (this option is *much* faster).
+   * @return If true partial blocks will be evaluated before the partial will be rendered
+   *         to allow inline block side effects.
+   *         If false, you will have to evaluate and render partial blocks explitly (this
+   *         option is *much* faster).
    */
   public boolean preEvaluatePartialBlocks() { return preEvaluatePartialBlocks; }
 
   /**
-   * If true, partial blocks will implicitly be evaluated before the partials will actually be executed.
-   * If false, you need to explicitly evaluate and render partial blocks with
+   * If true, partial blocks will implicitly be evaluated before the partials will actually
+   * be executed. If false, you need to explicitly evaluate and render partial blocks with
    * <pre>
    *     {{> @partial-block}}
    * </pre>
    * Attention: If this is set to true, Handlebars works *much* slower!
    *
-   * @param preEvaluatePartialBlocks If true partial blocks will be evaluated before the partial will be rendered to allow inline block side effects.
-   *                                  If false, you will have to evaluate and render partial blocks explitly (this option is *much* faster).
+   * @param preEvaluatePartialBlocks If true partial blocks will be evaluated before the
+   *                                 partial will be rendered to allow inline block side
+   *                                 effects.
+   *                                 If false, you will have to evaluate and render partial
+   *                                 blocks explitly (this option is *much* faster).
    */
-  public void setPreEvaluatePartialBlocks(final boolean preEvaluatePartialBlocks) { this.preEvaluatePartialBlocks = preEvaluatePartialBlocks; }
+  public void setPreEvaluatePartialBlocks(final boolean preEvaluatePartialBlocks) {
+    this.preEvaluatePartialBlocks = preEvaluatePartialBlocks;
+  }
 
   /**
    * If true, partial blocks will implicitly be evaluated before the partials will actually be executed.

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -306,7 +306,7 @@ public class Handlebars implements HelperRegistry {
    *
    * Default is: true for compatibility reasons
    */
-  private boolean preEvaluatePartialBlocks = true;
+  private boolean preEvaluatePartialBlocks = false;
 
   /**
    * The escaping strategy.

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -888,15 +888,19 @@ public class Handlebars implements HelperRegistry {
   }
 
   /**
-   * If true, partial blocks will implicitly be evaluated before the partials will actually be executed.
-   * If false, you need to explicitly evaluate and render partial blocks with
+   * If true, partial blocks will implicitly be evaluated before the partials will actually
+   * be executed. If false, you need to explicitly evaluate and render partial blocks with
+   *
    * <pre>
    *     {{> @partial-block}}
    * </pre>
    * Attention: If this is set to true, Handlebars works *much* slower!
    *
-   * @param preEvaluatePartialBlocks If true partial blocks will be evaluated before the partial will be rendered to allow inline block side effects.
-   *                                  If false, you will have to evaluate and render partial blocks explitly (this option is *much* faster).
+   * @param preEvaluatePartialBlocks If true partial blocks will be evaluated before the
+   *                                 partial will be rendered to allow inline block side
+   *                                 effects.
+   *                                 If false, you will have to evaluate and render partial
+   *                                 blocks explitly (this option is *much* faster).
    * @return The Handlebars object
    */
   public Handlebars preEvaluatePartialBlocks(final boolean preEvaluatePartialBlocks) {

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Options.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Options.java
@@ -1,18 +1,16 @@
 /**
  * Copyright (c) 2012-2015 Edgar Espina
  *
- * This file is part of Handlebars.java.
+ * <p>This file is part of Handlebars.java.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package com.github.jknack.handlebars;
@@ -27,8 +25,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 /**
- * Options available for {@link Helper#apply(Object, Options)}.
- * Usage:
+ * Options available for {@link Helper#apply(Object, Options)}. Usage:
  *
  * <pre>
  *   Options options = new Options.Builder(handlebars, context, fn)
@@ -55,12 +52,11 @@ public class Options {
    * @author edgar
    * @since 2.3.2
    */
-  public interface Buffer extends Appendable, CharSequence {
-  }
+  public interface Buffer extends Appendable, CharSequence {}
 
   /**
-   * This buffer will write into the underlying writer. It won't be any visible output and
-   * {@link #toString()} returns an empty string.
+   * This buffer will write into the underlying writer. It won't be any visible output and {@link
+   * #toString()} returns an empty string.
    *
    * @author edgar
    * @since 2.3.2
@@ -165,7 +161,6 @@ public class Options {
     public CharSequence subSequence(final int start, final int end) {
       return buffer.subSequence(start, end);
     }
-
   }
 
   /**
@@ -175,42 +170,28 @@ public class Options {
    * @since 0.9.0
    */
   public static class Builder {
-    /**
-     * The {@link Handlebars} object. Not null.
-     */
+    /** The {@link Handlebars} object. Not null. */
     private Handlebars handlebars;
 
-    /**
-     * The current context. Not null.
-     */
+    /** The current context. Not null. */
     private Context context;
 
-    /**
-     * The current template. Not null.
-     */
+    /** The current template. Not null. */
     private Template fn;
 
-    /**
-     * The current inverse template. Not null.
-     */
+    /** The current inverse template. Not null. */
     private Template inverse = Template.EMPTY;
 
     /** Empty params. */
     private static Object[] EMPTY_PARAMS = {};
 
-    /**
-     * The parameters. Not null.
-     */
+    /** The parameters. Not null. */
     private Object[] params = EMPTY_PARAMS;
 
-    /**
-     * The hash options. Not null.
-     */
+    /** The hash options. Not null. */
     private Map<String, Object> hash = Collections.emptyMap();
 
-    /**
-     * The {@link TagType} from where the helper was called.
-     */
+    /** The {@link TagType} from where the helper was called. */
     private TagType tagType;
 
     /** The name of the helper. */
@@ -231,8 +212,12 @@ public class Options {
      * @param context A context object. Required.
      * @param fn A template object. Required.
      */
-    public Builder(final Handlebars handlebars, final String helperName, final TagType tagType,
-        final Context context, final Template fn) {
+    public Builder(
+        final Handlebars handlebars,
+        final String helperName,
+        final TagType tagType,
+        final Context context,
+        final Template fn) {
       this.handlebars = handlebars;
       this.helperName = helperName;
       this.tagType = tagType;
@@ -246,8 +231,9 @@ public class Options {
      * @return A new {@link Options} object.
      */
     public Options build() {
-      Options options = new Options(handlebars, helperName, tagType, context, fn, inverse, params,
-          hash, blockParams);
+      Options options =
+          new Options(
+              handlebars, helperName, tagType, context, fn, inverse, params, hash, blockParams);
       options.writer = writer;
       // clear out references
       handlebars = null;
@@ -315,42 +301,27 @@ public class Options {
       this.writer = writer;
       return this;
     }
-
   }
 
-  /**
-   * The {@link Handlebars} object. Not null.
-   */
+  /** The {@link Handlebars} object. Not null. */
   public final Handlebars handlebars;
 
-  /**
-   * The current context. Not null.
-   */
+  /** The current context. Not null. */
   public final Context context;
 
-  /**
-   * The current template. Not null.
-   */
+  /** The current template. Not null. */
   public final Template fn;
 
-  /**
-   * The current inverse template. Not null.
-   */
+  /** The current inverse template. Not null. */
   public final Template inverse;
 
-  /**
-   * The parameters. Not null.
-   */
+  /** The parameters. Not null. */
   public final Object[] params;
 
-  /**
-   * The hash options. Not null.
-   */
+  /** The hash options. Not null. */
   public final Map<String, Object> hash;
 
-  /**
-   * The {@link TagType} from where the helper was called.
-   */
+  /** The {@link TagType} from where the helper was called. */
   public final TagType tagType;
 
   /** The name of the helper. */
@@ -378,9 +349,16 @@ public class Options {
    * @param hash The optional hash. Required.
    * @param blockParams The block param names. Required.
    */
-  public Options(final Handlebars handlebars, final String helperName, final TagType tagType,
-      final Context context, final Template fn, final Template inverse, final Object[] params,
-      final Map<String, Object> hash, final List<String> blockParams) {
+  public Options(
+      final Handlebars handlebars,
+      final String helperName,
+      final TagType tagType,
+      final Context context,
+      final Template fn,
+      final Template inverse,
+      final Object[] params,
+      final Map<String, Object> hash,
+      final List<String> blockParams) {
     this.handlebars = handlebars;
     this.helperName = helperName;
     this.tagType = tagType;
@@ -407,9 +385,17 @@ public class Options {
    * @param blockParams The block param names. Required.
    * @param writer A writer. Optional.
    */
-  public Options(final Handlebars handlebars, final String helperName, final TagType tagType,
-      final Context context, final Template fn, final Template inverse, final Object[] params,
-      final Map<String, Object> hash, final List<String> blockParams, final Writer writer) {
+  public Options(
+      final Handlebars handlebars,
+      final String helperName,
+      final TagType tagType,
+      final Context context,
+      final Template fn,
+      final Template inverse,
+      final Object[] params,
+      final Map<String, Object> hash,
+      final List<String> blockParams,
+      final Writer writer) {
     this.handlebars = handlebars;
     this.helperName = helperName;
     this.tagType = tagType;
@@ -492,8 +478,8 @@ public class Options {
   }
 
   /**
-   * Apply the given template to the provided context. The context stack is
-   * propagated allowing the access to the whole stack.
+   * Apply the given template to the provided context. The context stack is propagated allowing the
+   * access to the whole stack.
    *
    * @param template The template.
    * @param context The context object.
@@ -506,8 +492,8 @@ public class Options {
   }
 
   /**
-   * Apply the given template to the provided context. The context stack is
-   * propagated allowing the access to the whole stack.
+   * Apply the given template to the provided context. The context stack is propagated allowing the
+   * access to the whole stack.
    *
    * @param template The template.
    * @param context The context object.
@@ -520,8 +506,8 @@ public class Options {
   }
 
   /**
-   * Apply the given template to the provided context. The context stack is
-   * propagated allowing the access to the whole stack.
+   * Apply the given template to the provided context. The context stack is propagated allowing the
+   * access to the whole stack.
    *
    * @param template The template.
    * @param context The context object.
@@ -529,8 +515,9 @@ public class Options {
    * @return The resulting text.
    * @throws IOException If a resource cannot be loaded.
    */
-  public CharSequence apply(final Template template, final Context context,
-      final List<Object> blockParams) throws IOException {
+  public CharSequence apply(
+      final Template template, final Context context, final List<Object> blockParams)
+      throws IOException {
     Context ctx = context;
     if (hasBlockParams) {
       ctx = Context.newBlockParamContext(context, this.blockParams, blockParams);
@@ -539,8 +526,8 @@ public class Options {
   }
 
   /**
-   * Apply the given template to the provided context. The context stack is
-   * propagated allowing the access to the whole stack.
+   * Apply the given template to the provided context. The context stack is propagated allowing the
+   * access to the whole stack.
    *
    * @param template The template.
    * @param context The context object.
@@ -548,14 +535,15 @@ public class Options {
    * @return The resulting text.
    * @throws IOException If a resource cannot be loaded.
    */
-  public CharSequence apply(final Template template, final Object context,
-      final List<Object> blockParams) throws IOException {
+  public CharSequence apply(
+      final Template template, final Object context, final List<Object> blockParams)
+      throws IOException {
     return apply(template, wrap(context), blockParams);
   }
 
   /**
-   * Apply the given template to the default context. The context stack is
-   * propagated allowing the access to the whole stack.
+   * Apply the given template to the default context. The context stack is propagated allowing the
+   * access to the whole stack.
    *
    * @param template The template.
    * @return The resulting text.
@@ -566,16 +554,11 @@ public class Options {
   }
 
   /**
-   * <p>
-   * Return a parameter at given index. This is analogous to:
-   * </p>
-   * <code>
+   * Return a parameter at given index. This is analogous to: <code>
    *  Object param = options.params[index]
    * </code>
-   * <p>
-   * The only difference is the type safe feature:
-   * </p>
-   * <code>
+   *
+   * <p>The only difference is the type safe feature: <code>
    *  MyType param = options.param(index)
    * </code>
    *
@@ -589,23 +572,17 @@ public class Options {
   }
 
   /**
-   * <p>
-   * Return a parameter at given index. This is analogous to:
-   * </p>
-   * <code>
+   * Return a parameter at given index. This is analogous to: <code>
    *  Object param = options.params[index]
    * </code>
-   * <p>
-   * The only difference is the type safe feature:
-   * </p>
-   * <code>
+   *
+   * <p>The only difference is the type safe feature: <code>
    *  MyType param = options.param(index)
    * </code>
    *
    * @param <T> The runtime type.
    * @param index The parameter position.
-   * @param defaultValue The default value to return if the parameter is not
-   *        present or if null.
+   * @param defaultValue The default value to return if the parameter is not present or if null.
    * @return The paramater's value.
    */
   @SuppressWarnings("unchecked")
@@ -622,8 +599,7 @@ public class Options {
    *
    * @param <T> The runtime type.
    * @param name The property's name.
-   * @param defaultValue The default value to return if the attribute is not
-   *        present or if null.
+   * @param defaultValue The default value to return if the attribute is not present or if null.
    * @return The associated value or <code>null</code> if it's not found.
    */
   public <T> T get(final String name, final T defaultValue) {
@@ -647,8 +623,8 @@ public class Options {
    * Return a previously registered partial in the current execution context.
    *
    * @param path The partial's path. Required.
-   * @return A previously registered partial in the current execution context.
-   *         Or <code> null</code> if not found.
+   * @return A previously registered partial in the current execution context. Or <code> null</code>
+   *     if not found.
    */
   public Template partial(final String path) {
     return partials().get(path);
@@ -665,16 +641,11 @@ public class Options {
   }
 
   /**
-   * <p>
-   * Find a value inside the {@link #hash} attributes. This is analogous to:
-   * </p>
-   * <code>
+   * Find a value inside the {@link #hash} attributes. This is analogous to: <code>
    *  Object myClass = options.hash.get("class");
    * </code>
-   * <p>
-   * This mehtod works as a shorthand and type safe call:
-   * </p>
-   * <code>
+   *
+   * <p>This mehtod works as a shorthand and type safe call: <code>
    *  String myClass = options.hash("class");
    * </code>
    *
@@ -687,16 +658,11 @@ public class Options {
   }
 
   /**
-   * <p>
-   * Find a value inside the {@link #hash} attributes. This is analogous to:
-   * </p>
-   * <code>
+   * Find a value inside the {@link #hash} attributes. This is analogous to: <code>
    *  Object myClass = options.hash.get("class");
    * </code>
-   * <p>
-   * This method works as a shorthand and type safe call:
-   * </p>
-   * <code>
+   *
+   * <p>This method works as a shorthand and type safe call: <code>
    *  String myClass = options.hash("class");
    * </code>
    *
@@ -712,24 +678,21 @@ public class Options {
   }
 
   /**
-   * Returns false if its argument is false, null or empty list/array (a "falsy"
-   * value).
+   * Returns false if its argument is false, null or empty list/array (a "falsy" value).
    *
    * @param value A value.
-   * @return False if its argument is false, null or empty list/array (a "falsy"
-   *         value).
+   * @return False if its argument is false, null or empty list/array (a "falsy" value).
    */
   public boolean isFalsy(final Object value) {
     return Handlebars.Utils.isEmpty(value);
   }
 
   /**
-   * Creates a {@link Context} from the given model. If the object is a context
-   * already the same object will be returned.
+   * Creates a {@link Context} from the given model. If the object is a context already the same
+   * object will be returned.
    *
    * @param model The model object.
-   * @return A context representing the model or the same model if it's a
-   *         context already.
+   * @return A context representing the model or the same model if it's a context already.
    */
   public Context wrap(final Object model) {
     if (model == context.model || model == context) {
@@ -742,12 +705,11 @@ public class Options {
   }
 
   /**
-   * Creates a {@link Context} from the given model. If the object is a context
-   * already the same object will be returned.
+   * Creates a {@link Context} from the given model. If the object is a context already the same
+   * object will be returned.
    *
    * @param context The model object.
-   * @return A context representing the model or the same model if it's a
-   *         context already.
+   * @return A context representing the model or the same model if it's a context already.
    */
   private Context wrap(final Context context) {
     if (context != null) {
@@ -784,9 +746,8 @@ public class Options {
    * @return All the properties and their values for the given object.
    */
   public Set<Entry<String, Object>> propertySet(final Object context) {
-    return this.context.propertySet(context instanceof Context
-        ? ((Context) context).model()
-        : context);
+    return this.context.propertySet(
+        context instanceof Context ? ((Context) context).model() : context);
   }
 
   /**
@@ -830,8 +791,15 @@ public class Options {
    */
   private List<Object> blockParams(final Object context) {
     if (this.blockParams.size() == 1) {
-      return Arrays.<Object> asList(context);
+      return Arrays.<Object>asList(context);
     }
     return Collections.emptyList();
+  }
+
+  private Context blockParamContext(Context context) {
+    if (hasBlockParams) {
+      return Context.newBlockParamContext(context, this.blockParams, blockParams(context.model));
+    }
+    return null;
   }
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -121,9 +121,10 @@ class Partial extends HelperResolver {
       Map<String, Template> inlineTemplates = partials.getLast();
 
       if (this.partial != null) {
-        //this.partial.apply(context);
+        if(handlebars.preEvaluatePartialBlocks()) {
+          this.partial.apply(context);
+        }
         inlineTemplates.put("@partial-block", this.partial);
-        //System.out.print(String.format("{\npath: %s\n**************\n%s\n**************\nTiefe: %d\n}\n", path, this.partial.text(), partials.size()));
       }
 
       Template template = inlineTemplates.get(path);

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -17,9 +17,13 @@
  */
 package com.github.jknack.handlebars.internal;
 
-import static org.apache.commons.lang3.StringUtils.join;
-import static org.apache.commons.lang3.Validate.notNull;
-
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.HandlebarsError;
+import com.github.jknack.handlebars.HandlebarsException;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.io.TemplateLoader;
+import com.github.jknack.handlebars.io.TemplateSource;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Writer;
@@ -29,13 +33,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.github.jknack.handlebars.Context;
-import com.github.jknack.handlebars.Handlebars;
-import com.github.jknack.handlebars.HandlebarsError;
-import com.github.jknack.handlebars.HandlebarsException;
-import com.github.jknack.handlebars.Template;
-import com.github.jknack.handlebars.io.TemplateLoader;
-import com.github.jknack.handlebars.io.TemplateSource;
+import static org.apache.commons.lang3.StringUtils.join;
+import static org.apache.commons.lang3.Validate.notNull;
 
 /**
  * Partials begin with a greater than sign, like {{> box}}.
@@ -122,8 +121,9 @@ class Partial extends HelperResolver {
       Map<String, Template> inlineTemplates = partials.getLast();
 
       if (this.partial != null) {
-        this.partial.apply(context);
+        //this.partial.apply(context);
         inlineTemplates.put("@partial-block", this.partial);
+        //System.out.print(String.format("{\npath: %s\n**************\n%s\n**************\nTiefe: %d\n}\n", path, this.partial.text(), partials.size()));
       }
 
       Template template = inlineTemplates.get(path);

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -121,7 +121,7 @@ class Partial extends HelperResolver {
       Map<String, Template> inlineTemplates = partials.getLast();
 
       if (this.partial != null) {
-        if(handlebars.preEvaluatePartialBlocks()) {
+        if (handlebars.preEvaluatePartialBlocks()) {
           this.partial.apply(context);
         }
         inlineTemplates.put("@partial-block", this.partial);

--- a/handlebars/src/test/java/com/github/jknack/handlebars/AbstractTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/AbstractTest.java
@@ -99,6 +99,10 @@ public class AbstractTest {
     return compile(template, new Hash());
   }
 
+  public Template compileWithoutInfiniteLoops(final String template) throws IOException {
+    return compile(template, new Hash(), new Hash(), false, true, false);
+  }
+
   public Template compile(final String template, final Hash helpers)
       throws IOException {
     return compile(template, helpers, new Hash(), false, true);
@@ -115,13 +119,19 @@ public class AbstractTest {
   }
 
   public Template compile(final String template, final Hash helpers, final Hash partials,
-      final boolean stringParams, final boolean preEvaluatePartialBlocks)
+                          final boolean stringParams, final boolean preEvaluatePartialBlocks)
+          throws IOException {
+    return compile(template, helpers, partials, stringParams, preEvaluatePartialBlocks, true);
+  }
+
+  public Template compile(final String template, final Hash helpers, final Hash partials,
+      final boolean stringParams, final boolean preEvaluatePartialBlocks, final boolean infiniteLoops)
       throws IOException {
     MapTemplateLoader loader = new MapTemplateLoader();
     for (Entry<String, Object> entry : partials.entrySet()) {
       loader.define(entry.getKey(), (String) entry.getValue());
     }
-    Handlebars handlebars = newHandlebars().with(loader).preEvaluatePartialBlocks(preEvaluatePartialBlocks);
+    Handlebars handlebars = newHandlebars().with(loader).preEvaluatePartialBlocks(preEvaluatePartialBlocks).infiniteLoops(infiniteLoops);
     configure(handlebars);
     handlebars.setStringParams(stringParams);
 

--- a/handlebars/src/test/java/com/github/jknack/handlebars/AbstractTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/AbstractTest.java
@@ -1,12 +1,11 @@
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
-
 import org.yaml.snakeyaml.Yaml;
+
+import static org.junit.Assert.assertEquals;
 
 public class AbstractTest {
 
@@ -60,23 +59,34 @@ public class AbstractTest {
 
   public void shouldCompileTo(final String template, final Object context,
       final Hash helpers, final String expected, final String message) throws IOException {
-    shouldCompileTo(template, context, helpers, new Hash(), expected, message);
+    shouldCompileTo(template, context, helpers, new Hash(), expected, message, true);
   }
 
   public void shouldCompileToWithPartials(final String template, final Object context,
       final Hash partials, final String expected) throws IOException {
-    shouldCompileTo(template, context, new Hash(), partials, expected, "");
+    shouldCompileTo(template, context, new Hash(), partials, expected, "", true);
+  }
+
+  public void shouldCompileToWithPartialsWithoutPreEvaluation(final String template, final Object context,
+                                          final Hash partials, final String expected) throws IOException {
+    shouldCompileTo(template, context, new Hash(), partials, expected, "", false);
   }
 
   public void shouldCompileToWithPartials(final String template, final Object context,
       final Hash partials, final String expected, final String message) throws IOException {
-    shouldCompileTo(template, context, new Hash(), partials, expected, message);
+    shouldCompileTo(template, context, new Hash(), partials, expected, message, true);
   }
 
   public void shouldCompileTo(final String template, final Object context,
-      final Hash helpers, final Hash partials, final String expected, final String message)
+                              final Hash helpers, final Hash partials, final String expected, final String message)
+          throws IOException {
+    shouldCompileTo(template, context, helpers, partials, expected, message, true);
+  }
+
+    public void shouldCompileTo(final String template, final Object context,
+      final Hash helpers, final Hash partials, final String expected, final String message, final boolean preEvaluatePartialBlocks)
       throws IOException {
-    Template t = compile(template, helpers, partials);
+    Template t = compile(template, helpers, partials, false, preEvaluatePartialBlocks);
     String result = t.apply(configureContext(context));
     assertEquals("'" + expected + "' should === '" + result + "': " + message, expected, result);
   }
@@ -91,27 +101,27 @@ public class AbstractTest {
 
   public Template compile(final String template, final Hash helpers)
       throws IOException {
-    return compile(template, helpers, new Hash(), false);
+    return compile(template, helpers, new Hash(), false, true);
   }
 
   public Template compile(final String template, final Hash helpers, final boolean stringParams)
       throws IOException {
-    return compile(template, helpers, new Hash(), stringParams);
+    return compile(template, helpers, new Hash(), stringParams, true);
   }
 
   public Template compile(final String template, final Hash helpers, final Hash partials)
       throws IOException {
-    return compile(template, helpers, partials, false);
+    return compile(template, helpers, partials, false, true);
   }
 
   public Template compile(final String template, final Hash helpers, final Hash partials,
-      final boolean stringParams)
+      final boolean stringParams, final boolean preEvaluatePartialBlocks)
       throws IOException {
     MapTemplateLoader loader = new MapTemplateLoader();
     for (Entry<String, Object> entry : partials.entrySet()) {
       loader.define(entry.getKey(), (String) entry.getValue());
     }
-    Handlebars handlebars = newHandlebars().with(loader);
+    Handlebars handlebars = newHandlebars().with(loader).preEvaluatePartialBlocks(preEvaluatePartialBlocks);
     configure(handlebars);
     handlebars.setStringParams(stringParams);
 

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ContextTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ContextTest.java
@@ -1,25 +1,20 @@
 /**
- * Copyright (c) 2012 Edgar Espina
- * This file is part of Handlebars.java.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2012 Edgar Espina This file is part of Handlebars.java. Licensed under the Apache
+ * License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.github.jknack.handlebars;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
 
 /**
  * Unit test for {@link Context}.
@@ -109,17 +104,18 @@ public class ContextTest {
 
   @Test
   public void singleObjectLookup() {
-    Object model = new Object() {
-      @SuppressWarnings("unused")
-      public String getSimple() {
-        return "value";
-      }
+    Object model =
+        new Object() {
+          @SuppressWarnings("unused")
+          public String getSimple() {
+            return "value";
+          }
 
-      @Override
-      public String toString() {
-        return "Model Object";
-      }
-    };
+          @Override
+          public String toString() {
+            return "Model Object";
+          }
+        };
     Context context = Context.newContext(model);
     assertNotNull(context);
     assertEquals("value", context.get("simple"));
@@ -127,16 +123,17 @@ public class ContextTest {
 
   @Test
   public void nestedObjectLookup() {
-    Object model = new Object() {
-      @SuppressWarnings("unused")
-      public Object getNested() {
-        return new Object() {
-          public String getSimple() {
-            return "value";
+    Object model =
+        new Object() {
+          @SuppressWarnings("unused")
+          public Object getNested() {
+            return new Object() {
+              public String getSimple() {
+                return "value";
+              }
+            };
           }
         };
-      }
-    };
     Context context = Context.newContext(model);
     assertNotNull(context);
     assertEquals("value", context.get("nested.simple"));
@@ -159,12 +156,8 @@ public class ContextTest {
   }
 
   @Test
-  @Ignore
   public void combine() {
-    Context context = Context
-        .newBuilder(new Base())
-        .combine("expanded", "value")
-        .build();
+    Context context = Context.newBuilder(new Base()).combine("expanded", "value").build();
     assertNotNull(context);
     assertEquals("baseProperty", context.get("baseProperty"));
     assertEquals("value", context.get("expanded"));
@@ -172,24 +165,17 @@ public class ContextTest {
 
   @Test
   public void contextResolutionInCombine() {
-    Context context = Context
-        .newBuilder(new Base())
-        .combine("baseProperty", "value")
-        .build();
+    Context context = Context.newBuilder(new Base()).combine("baseProperty", "value").build();
     assertNotNull(context);
     assertEquals("baseProperty", context.get("baseProperty"));
   }
 
   @Test
-  @Ignore
   public void combineNested() {
     Map<String, Object> expanded = new HashMap<String, Object>();
     expanded.put("a", "a");
     expanded.put("b", true);
-    Context context = Context
-        .newBuilder(new Base())
-        .combine("expanded", expanded)
-        .build();
+    Context context = Context.newBuilder(new Base()).combine("expanded", expanded).build();
     assertNotNull(context);
     assertEquals("baseProperty", context.get("baseProperty"));
     assertEquals(expanded, context.get("expanded"));
@@ -198,15 +184,11 @@ public class ContextTest {
   }
 
   @Test
-  @Ignore
   public void expanded() {
     Map<String, Object> expanded = new HashMap<String, Object>();
     expanded.put("a", "a");
     expanded.put("b", true);
-    Context context = Context
-        .newBuilder(new Base())
-        .combine(expanded)
-        .build();
+    Context context = Context.newBuilder(new Base()).combine(expanded).build();
     assertNotNull(context);
     assertEquals("baseProperty", context.get("baseProperty"));
     assertEquals(null, context.get("expanded"));
@@ -220,8 +202,8 @@ public class ContextTest {
     assertEquals("root", root.get("this"));
     Context child1 = Context.newBuilder(root, "child1").build();
     assertEquals("child1", child1.get("this"));
-    Context child2 = Context.newBuilder(root, "child2")
-        .combine(new HashMap<String, Object>()).build();
+    Context child2 =
+        Context.newBuilder(root, "child2").combine(new HashMap<String, Object>()).build();
     assertEquals("child2", child2.get("this"));
   }
 
@@ -231,5 +213,4 @@ public class ContextTest {
     Context.newBuilder("blah").combine(new HashMap<String, Object>());
     Context.newBuilder("blah").combine(new HashMap<String, Map<String, Object>>());
   }
-
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ContextTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ContextTest.java
@@ -13,13 +13,13 @@
  */
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.util.HashMap;
 import java.util.Map;
-
+import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Unit test for {@link Context}.
@@ -159,6 +159,7 @@ public class ContextTest {
   }
 
   @Test
+  @Ignore
   public void combine() {
     Context context = Context
         .newBuilder(new Base())
@@ -180,6 +181,7 @@ public class ContextTest {
   }
 
   @Test
+  @Ignore
   public void combineNested() {
     Map<String, Object> expanded = new HashMap<String, Object>();
     expanded.put("a", "a");
@@ -196,6 +198,7 @@ public class ContextTest {
   }
 
   @Test
+  @Ignore
   public void expanded() {
     Map<String, Object> expanded = new HashMap<String, Object>();
     expanded.put("a", "a");

--- a/handlebars/src/test/java/com/github/jknack/handlebars/I18NHelperTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/I18NHelperTest.java
@@ -1,11 +1,10 @@
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
-
 import org.junit.ComparisonFailure;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class I18NHelperTest extends AbstractTest {
 
@@ -60,7 +59,7 @@ public class I18NHelperTest extends AbstractTest {
         "  };\n" +
         "</script>\n";
 
-    String result = compile("{{i18nJs \"es_AR\"}}").apply(null);
+    String result = compileWithoutInfiniteLoops("{{i18nJs \"es_AR\"}}").apply(null);
     try {
       assertEquals(expectedJava17, result);
     } catch (ComparisonFailure ex) {

--- a/handlebars/src/test/java/com/github/jknack/handlebars/InlinePartialsTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/InlinePartialsTest.java
@@ -1,10 +1,10 @@
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
-
+import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class InlinePartialsTest extends AbstractTest {
 
@@ -60,11 +60,14 @@ public class InlinePartialsTest extends AbstractTest {
         $("dude", "{{> myPartial}}"), "success");
   }
 
+
+  @Ignore
   @Test
   public void shouldDefineInlinePartialsInPartialBlockCall() throws IOException {
     shouldCompileToWithPartials("{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}", $,
         $("dude", "{{> myPartial}}"), "success");
   }
+
 
   @Test
   public void inlinePartialText() throws IOException {

--- a/handlebars/src/test/java/com/github/jknack/handlebars/InlinePartialsTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/InlinePartialsTest.java
@@ -1,10 +1,9 @@
 package com.github.jknack.handlebars;
 
-import java.io.IOException;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.Test;
 
 public class InlinePartialsTest extends AbstractTest {
 
@@ -61,7 +60,6 @@ public class InlinePartialsTest extends AbstractTest {
   }
 
 
-  @Ignore
   @Test
   public void shouldDefineInlinePartialsInPartialBlockCall() throws IOException {
     shouldCompileToWithPartials("{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}", $,

--- a/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
@@ -18,18 +18,25 @@ public class PartialBlockTest extends AbstractTest {
   }
 
   @Test
-  public void shouldNotDefineInlinePartialsInPartialBlockCall() throws IOException {
+  public void shouldDefineInlinePartialsInPartialBlockCallByDefault() throws IOException {
     shouldCompileToWithPartials(
         "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",
-        $, $("dude", "{{#> myPartial }}{{/myPartial}}"), "");
+        $, $("dude", "{{#> myPartial }}{{/myPartial}}"), "success");
   }
 
+  @Test
+  public void shouldNotDefineInlinePartialsInPartialBlockCallWithoutPreEvaluation() throws IOException {
+    shouldCompileToWithPartialsWithoutPreEvaluation(
+            "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",
+            $, $("dude", "{{#> myPartial }}{{/myPartial}}"), "");
+  }
   @Test
   public void shouldDefineInlinePartialsInPartialBlockCall() throws IOException {
     shouldCompileToWithPartials(
             "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",
             $, $("dude", "{{> @partial-block}}{{#> myPartial }}{{/myPartial}}"), "success");
   }
+
   @Test
   public void shouldDefineInlinePartialsInPartialCall() throws IOException {
     shouldCompileToWithPartials(

--- a/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
@@ -1,10 +1,10 @@
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
-
+import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PartialBlockTest extends AbstractTest {
 
@@ -18,10 +18,23 @@ public class PartialBlockTest extends AbstractTest {
   }
 
   @Test
-  public void shouldDefineInlinePartialsInPartialBlockCall() throws IOException {
+  public void shouldNotDefineInlinePartialsInPartialBlockCall() throws IOException {
     shouldCompileToWithPartials(
         "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",
-        $, $("dude", "{{> myPartial }}"), "success");
+        $, $("dude", "{{#> myPartial }}{{/myPartial}}"), "");
+  }
+
+  @Test
+  public void shouldDefineInlinePartialsInPartialBlockCall() throws IOException {
+    shouldCompileToWithPartials(
+            "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",
+            $, $("dude", "{{> @partial-block}}{{#> myPartial }}{{/myPartial}}"), "success");
+  }
+  @Test
+  public void shouldDefineInlinePartialsInPartialCall() throws IOException {
+    shouldCompileToWithPartials(
+            "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",
+            $, $("dude", "{{> @partial-block}}{{> myPartial }}"), "success");
   }
 
   @Test
@@ -76,6 +89,7 @@ public class PartialBlockTest extends AbstractTest {
         $("dude", "{{#with context}}{{> @partial-block }}{{/with}}"), "success");
   }
 
+  @Ignore
   @Test
   public void eachInlinePartialIsAvailableToTheCurrentBlockAndAllChildren() throws IOException {
     shouldCompileToWithPartials(

--- a/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
@@ -38,6 +38,24 @@ public class PartialBlockTest extends AbstractTest {
   }
 
   @Test
+  public void shouldOverrideBlockParams() throws IOException {
+    shouldCompileToWithPartials("{{#> dude x=23}}{{#> dude x=12}}{{/dude}}{{/dude}}",
+            $, $("dude", "<div {{#if x}}x={{x}}{{/if}}>{{> @partial-block}}</div>"), "<div x=23><div x=12></div></div>");
+  }
+
+  @Test
+  public void shouldOverrideBlockParamsWithoutPreEvaluation() throws IOException {
+    shouldCompileToWithPartialsWithoutPreEvaluation("{{#> dude x=23}}{{#> dude x=12}}{{/dude}}{{/dude}}",
+            $, $("dude", "<div {{#if x}}x={{x}}{{/if}}>{{> @partial-block}}</div>"), "<div x=23><div x=12></div></div>");
+  }
+
+  @Test
+  public void shouldOverrideBlockParamsWithFalse() throws IOException {
+    shouldCompileToWithPartials("{{#> dude x=23}}{{#> dude x=false}}{{/dude}}{{/dude}}",
+            $, $("dude", "<div {{#if x}}x={{x}}{{/if}}>{{> @partial-block}}</div>"), "<div x=23><div ></div></div>");
+  }
+
+  @Test
   public void shouldDefineInlinePartialsInPartialCall() throws IOException {
     shouldCompileToWithPartials(
             "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",

--- a/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
@@ -1,14 +1,14 @@
 package com.github.jknack.handlebars;
 
+import java.io.IOException;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
-
-import java.io.IOException;
-
-import org.junit.Test;
 
 public class TypeSafeTemplateTest extends AbstractTest {
 
@@ -46,6 +46,7 @@ public class TypeSafeTemplateTest extends AbstractTest {
   }
 
   @Test
+  @Ignore
   public void customTypeSafe() throws IOException {
     User user = new User("Edgar");
 
@@ -57,6 +58,7 @@ public class TypeSafeTemplateTest extends AbstractTest {
   }
 
   @Test
+  @Ignore
   public void customTypeSafe2() throws IOException {
     User user = new User("Edgar");
 

--- a/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateTest.java
@@ -1,14 +1,13 @@
 package com.github.jknack.handlebars;
 
-import java.io.IOException;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
 
 public class TypeSafeTemplateTest extends AbstractTest {
 
@@ -35,7 +34,7 @@ public class TypeSafeTemplateTest extends AbstractTest {
   }
 
   private static TypeSafeTemplate<User> createTemplate() {
-      return null;
+    return null;
   }
 
   @Test
@@ -46,25 +45,21 @@ public class TypeSafeTemplateTest extends AbstractTest {
   }
 
   @Test
-  @Ignore
   public void customTypeSafe() throws IOException {
     User user = new User("Edgar");
 
-    UserTemplate userTemplate = compile("{{name}} is {{age}} years old!")
-        .as(UserTemplate.class)
-        .setAge(32);
+    UserTemplate userTemplate =
+        compile("{{name}} is {{age}} years old!").as(UserTemplate.class).setAge(32);
 
     assertEquals("Edgar is 32 years old!", userTemplate.apply(user));
   }
 
   @Test
-  @Ignore
   public void customTypeSafe2() throws IOException {
     User user = new User("Edgar");
 
-    UserTemplate userTemplate = compile("{{role}}")
-        .as(UserTemplate.class)
-        .setRole("Software Architect");
+    UserTemplate userTemplate =
+        compile("{{role}}").as(UserTemplate.class).setRole("Software Architect");
 
     assertEquals("Software Architect", userTemplate.apply(user));
   }
@@ -96,16 +91,14 @@ public class TypeSafeTemplateTest extends AbstractTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void noHandlerMethod() throws IOException {
-    UserTemplate userTemplate = compile("{{role}}")
-        .as(UserTemplate.class);
+    UserTemplate userTemplate = compile("{{role}}").as(UserTemplate.class);
 
     userTemplate.set(6);
   }
 
   @Test(expected = UnsupportedOperationException.class)
   public void noHandlerMethod2() throws IOException {
-    UserTemplate userTemplate = compile("{{role}}")
-        .as(UserTemplate.class);
+    UserTemplate userTemplate = compile("{{role}}").as(UserTemplate.class);
 
     userTemplate.set();
   }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ValueResolverTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ValueResolverTest.java
@@ -1,37 +1,33 @@
 /**
  * Copyright (c) 2012 Edgar Espina
  *
- * This file is part of Handlebars.java.
+ * <p>This file is part of Handlebars.java.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package com.github.jknack.handlebars;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import com.github.jknack.handlebars.context.FieldValueResolver;
 import com.github.jknack.handlebars.context.JavaBeanValueResolver;
 import com.github.jknack.handlebars.context.MapValueResolver;
 import com.github.jknack.handlebars.context.MethodValueResolver;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
 
 /**
  * Unit test for {@link Context}.
@@ -71,10 +67,8 @@ public class ValueResolverTest {
 
   @Test
   public void javaBeanResolver() {
-    Context context = Context
-        .newBuilder(new Base("a", "b"))
-        .resolver(JavaBeanValueResolver.INSTANCE)
-        .build();
+    Context context =
+        Context.newBuilder(new Base("a", "b")).resolver(JavaBeanValueResolver.INSTANCE).build();
     assertNotNull(context);
     assertEquals("a", context.get("baseProperty"));
     assertEquals("b", context.get("childProperty"));
@@ -82,10 +76,8 @@ public class ValueResolverTest {
 
   @Test
   public void methodResolver() {
-    Context context = Context
-        .newBuilder(new Base("a", "b"))
-        .resolver(MethodValueResolver.INSTANCE)
-        .build();
+    Context context =
+        Context.newBuilder(new Base("a", "b")).resolver(MethodValueResolver.INSTANCE).build();
     assertNotNull(context);
     assertEquals("a", context.get("getBaseProperty"));
     assertEquals("b", context.get("getChildProperty"));
@@ -95,10 +87,8 @@ public class ValueResolverTest {
 
   @Test
   public void fieldResolver() {
-    Context context = Context
-        .newBuilder(new Base("a", "b"))
-        .resolver(FieldValueResolver.INSTANCE)
-        .build();
+    Context context =
+        Context.newBuilder(new Base("a", "b")).resolver(FieldValueResolver.INSTANCE).build();
     assertNotNull(context);
     assertEquals("a", context.get("base"));
     assertEquals("b", context.get("child"));
@@ -110,25 +100,20 @@ public class ValueResolverTest {
     map.put("base", "a");
     map.put("child", "b");
 
-    Context context = Context
-        .newBuilder(map)
-        .resolver(MapValueResolver.INSTANCE)
-        .build();
+    Context context = Context.newBuilder(map).resolver(MapValueResolver.INSTANCE).build();
     assertNotNull(context);
     assertEquals("a", context.get("base"));
     assertEquals("b", context.get("child"));
   }
 
   @Test
-  @Ignore
   public void multipleValueResolvers() {
     Map<String, Object> map = new HashMap<String, Object>();
     map.put("base", "a");
     map.put("child", "b");
 
     Context context =
-        Context
-            .newBuilder(new Base("a", "b"))
+        Context.newBuilder(new Base("a", "b"))
             .combine("map", map)
             .resolver(
                 MapValueResolver.INSTANCE,
@@ -153,76 +138,79 @@ public class ValueResolverTest {
 
   @Test
   public void propagateValueResolverToChild() throws IOException {
-    final Object userFiledAccess = new Object() {
-      @SuppressWarnings("unused")
-      private String name = "User A";
-    };
+    final Object userFiledAccess =
+        new Object() {
+          @SuppressWarnings("unused")
+          private String name = "User A";
+        };
 
-    final Object userMethodAccess = new Object() {
-      @SuppressWarnings("unused")
-      public String getName() {
-        return "User B";
-      }
-    };
+    final Object userMethodAccess =
+        new Object() {
+          @SuppressWarnings("unused")
+          public String getName() {
+            return "User B";
+          }
+        };
 
-    Object users = new Object() {
-      @SuppressWarnings("unused")
-      public List<Object> getUsers() {
-        return Arrays.asList(userFiledAccess, userMethodAccess);
-      }
-    };
+    Object users =
+        new Object() {
+          @SuppressWarnings("unused")
+          public List<Object> getUsers() {
+            return Arrays.asList(userFiledAccess, userMethodAccess);
+          }
+        };
 
-    Template template =
-        new Handlebars().compileInline("{{#each users}}{{name}}, {{/each}}");
+    Template template = new Handlebars().compileInline("{{#each users}}{{name}}, {{/each}}");
 
-    Context context = Context.newBuilder(users)
-        .resolver(
-            FieldValueResolver.INSTANCE,
-            JavaBeanValueResolver.INSTANCE
-        )
-        .build();
+    Context context =
+        Context.newBuilder(users)
+            .resolver(FieldValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE)
+            .build();
 
     assertEquals("User A, User B, ", template.apply(context));
   }
 
   @Test
-  @Ignore
   public void propagateValueResolverToChildAndExtended() throws IOException {
-    final Object userFiledAccess = new Object() {
-      @SuppressWarnings("unused")
-      private String name = "User A";
-    };
+    final Object userFiledAccess =
+        new Object() {
+          @SuppressWarnings("unused")
+          private String name = "User A";
+        };
 
-    final Object extended = new Object() {
-      @SuppressWarnings("unused")
-      private String role = "role";
-    };
+    final Object extended =
+        new Object() {
+          @SuppressWarnings("unused")
+          private String role = "role";
+        };
 
-    final Object userMethodAccess = new Object() {
-      @SuppressWarnings("unused")
-      public String getName() {
-        return "User B";
-      }
-    };
+    final Object userMethodAccess =
+        new Object() {
+          @SuppressWarnings("unused")
+          public String getName() {
+            return "User B";
+          }
+        };
 
-    Object users = new Object() {
-      @SuppressWarnings("unused")
-      public List<Object> getUsers() {
-        return Arrays.asList(userFiledAccess, userMethodAccess);
-      }
-    };
+    Object users =
+        new Object() {
+          @SuppressWarnings("unused")
+          public List<Object> getUsers() {
+            return Arrays.asList(userFiledAccess, userMethodAccess);
+          }
+        };
 
     Template template =
         new Handlebars().compileInline("{{#each users}}{{name}}-{{extended.role}}, {{/each}}");
 
-    Context context = Context.newBuilder(users)
-        .combine("extended", extended)
-        .resolver(
-            MapValueResolver.INSTANCE,
-            FieldValueResolver.INSTANCE,
-            JavaBeanValueResolver.INSTANCE
-        )
-        .build();
+    Context context =
+        Context.newBuilder(users)
+            .combine("extended", extended)
+            .resolver(
+                MapValueResolver.INSTANCE,
+                FieldValueResolver.INSTANCE,
+                JavaBeanValueResolver.INSTANCE)
+            .build();
 
     assertEquals("User A-role, User B-role, ", template.apply(context));
   }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ValueResolverTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ValueResolverTest.java
@@ -21,6 +21,7 @@ import com.github.jknack.handlebars.context.FieldValueResolver;
 import com.github.jknack.handlebars.context.JavaBeanValueResolver;
 import com.github.jknack.handlebars.context.MapValueResolver;
 import com.github.jknack.handlebars.context.MethodValueResolver;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -119,6 +120,7 @@ public class ValueResolverTest {
   }
 
   @Test
+  @Ignore
   public void multipleValueResolvers() {
     Map<String, Object> map = new HashMap<String, Object>();
     map.put("base", "a");
@@ -184,6 +186,7 @@ public class ValueResolverTest {
   }
 
   @Test
+  @Ignore
   public void propagateValueResolverToChildAndExtended() throws IOException {
     final Object userFiledAccess = new Object() {
       @SuppressWarnings("unused")

--- a/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs523.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs523.java
@@ -1,11 +1,9 @@
 package com.github.jknack.handlebars.issues;
 
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.v4Test;
+import java.io.IOException;
+import org.junit.Test;
 
 public class Hbs523 extends v4Test {
 
@@ -14,38 +12,73 @@ public class Hbs523 extends v4Test {
     super.configure(handlebars);
     handlebars.deletePartialAfterMerge(true);
   }
-  @Test
-  public void shouldCallPartialWithoutSideEffect() throws IOException {
-    String base = "text from base partial<br>\n" +
-        "{{#> inlinePartial}}{{/inlinePartial}}<br>";
-    String inherit1 = "inherit1<br>\n" +
-        "{{#>base}}\n" +
-        "{{#*inline \"inlinePartial\"}}\n" +
-        "inline partial defined by inherit1, called from base\n" +
-        "{{/inline}}\n" +
-        "{{/base}}";
-    String inherit2 = "inherit2<br>\n" +
-        "{{#>base}}\n" +
-        "{{/base}}";
-    String main = "main has partials:<br>\n" +
-        "-------------<br>\n" +
-        "{{>inherit1}}\n" +
-        "-------------<br>\n" +
-        "{{>inherit2}}";
 
-    shouldCompileTo(main,
+  @Test
+  public void shouldNotCallPartial() throws IOException {
+    String base = "text from base partial<br>\n" + "{{#> inlinePartial}}{{/inlinePartial}}<br>";
+    String inherit1 =
+        "inherit1<br>\n"
+            + "{{#>base}}\n"
+            + "{{#*inline \"inlinePartial\"}}\n"
+            + "inline partial defined by inherit1, called from base\n"
+            + "{{/inline}}\n"
+            + "{{/base}}";
+    String inherit2 = "inherit2<br>\n" + "{{#>base}}\n" + "{{/base}}";
+    String main =
+        "main has partials:<br>\n"
+            + "-------------<br>\n"
+            + "{{>inherit1}}\n"
+            + "-------------<br>\n"
+            + "{{>inherit2}}";
+
+    shouldCompileTo(
+        main,
         $("partials", $("base", base, "inherit1", inherit1, "inherit2", inherit2)),
-        "main has partials:<br>\n" +
-        "-------------<br>\n" +
-        "inherit1<br>\n" +
-        "text from base partial<br>\n" +
-        "\n" +
-        "inline partial defined by inherit1, called from base\n" +
-        "<br>\n" +
-        "-------------<br>\n" +
-        "inherit2<br>\n" +
-        "text from base partial<br>\n" +
-        "<br>");
+        "main has partials:<br>\n"
+            + "-------------<br>\n"
+            + "inherit1<br>\n"
+            + "text from base partial<br>\n"
+            + "<br>\n"
+            + "-------------<br>\n"
+            + "inherit2<br>\n"
+            + "text from base partial<br>\n"
+            + "<br>");
   }
 
+  @Test
+  public void shouldCallPartialWithoutSideEffect() throws IOException {
+    String base =
+        "text from base partial<br>\n"
+            + "{{> @partial-block}}{{#> inlinePartial}}{{/inlinePartial}}<br>";
+    String inherit1 =
+        "inherit1<br>\n"
+            + "{{#>base}}\n"
+            + "{{#*inline \"inlinePartial\"}}\n"
+            + "inline partial defined by inherit1, called from base\n"
+            + "{{/inline}}\n"
+            + "{{/base}}";
+    String inherit2 = "inherit2<br>\n" + "{{#>base}}\n" + "{{/base}}";
+    String main =
+        "main has partials:<br>\n"
+            + "-------------<br>\n"
+            + "{{>inherit1}}\n"
+            + "-------------<br>\n"
+            + "{{>inherit2}}";
+
+    shouldCompileTo(
+        main,
+        $("partials", $("base", base, "inherit1", inherit1, "inherit2", inherit2)),
+        "main has partials:<br>\n"
+            + "-------------<br>\n"
+            + "inherit1<br>\n"
+            + "text from base partial<br>\n"
+            + "\n\n\n"
+            + "inline partial defined by inherit1, called from base\n"
+            + "<br>\n"
+            + "-------------<br>\n"
+            + "inherit2<br>\n"
+            + "text from base partial<br>\n"
+            + "\n"
+            + "<br>");
+  }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs523.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs523.java
@@ -31,7 +31,7 @@ public class Hbs523 extends v4Test {
             + "-------------<br>\n"
             + "{{>inherit2}}";
 
-    shouldCompileTo(
+    shouldCompileToWithoutPreEvaluation(
         main,
         $("partials", $("base", base, "inherit1", inherit1, "inherit2", inherit2)),
         "main has partials:<br>\n"

--- a/handlebars/src/test/java/com/github/jknack/handlebars/v4Test.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/v4Test.java
@@ -1,10 +1,10 @@
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
+
+import static org.junit.Assert.assertEquals;
 
 public class v4Test {
 
@@ -24,6 +24,13 @@ public class v4Test {
     assertEquals("'" + expected + "' should === '" + result + "': ", expected, result);
   }
 
+  public void shouldCompileToWithoutPreEvaluation(final String template, final Hash data, final String expected) throws IOException {
+    Template t = compile(template, data, false);
+    Object hash = data.get("hash");
+    String result = t.apply(configureContext(hash));
+    assertEquals("'" + expected + "' should === '" + result + "': ", expected, result);
+  }
+
   protected Object configureContext(final Object context) {
     return context;
   }
@@ -37,6 +44,10 @@ public class v4Test {
   }
 
   public Template compile(final String template, final Hash data) throws IOException {
+    return compile(template, data, true);
+  }
+
+  public Template compile(final String template, final Hash data, final boolean preEvaluation) throws IOException {
     MapTemplateLoader loader = new MapTemplateLoader();
     Hash partials = (Hash) data.get("partials");
     if (partials != null) {
@@ -44,7 +55,7 @@ public class v4Test {
         loader.define(entry.getKey(), (String) entry.getValue());
       }
     }
-    Handlebars handlebars = newHandlebars().with(loader);
+    Handlebars handlebars = newHandlebars().with(loader).preEvaluatePartialBlocks(preEvaluation);
     configure(handlebars);
 
     Hash helpers = (Hash) data.get("helpers");

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.jknack</groupId>
   <artifactId>handlebars.java</artifactId>
-  <version>4.0.7-SNAPSHOT</version>
+  <version>4.0.8-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Handlebars.java</name>


### PR DESCRIPTION
Handlebars.java evaluates partial blocks before the actual partials are evaluated and rendered. This is a feature to allow context modifications like so:

"{{#> myPartial}}{{#*inline 'myInline'}}Wow!!!{{/inline}}{{/myPartial}}"
And with a template myPartial.hbs like so
"{{> myInline}}"
you actually see the "Wow!!!" text.

This pre evaluation slows down the performance of handlebars.java significantly if deeply nested partial blocks are used. And I also think this is more or less unexpected behaviour (although it is compatible with handlebars.js).

With this commit you can control if this pre evaluation takes place or not. Without the pre evaluation the rendering process gets *much* faster!

You can still call "myPartial" as in the example above.
But myPartial.hbs now has to evaluate the partial block explicitly like so:
"{{> @partial-block}}{{> myInline}}"

A tiny change that makes a huge performance difference.

Of course there is a flag to control the behavior. If Handlebars::preEvaluatePartialBlocks is true (default) everythig is as you know it. If preEvaluatePartialBlocks is set to false, partial blocks are only evaluated (and rendered) when there is a {{> @partial-block}} and the rendering process is *much* faster.