### PR TITLE
Added JavaDoc: Handlebars.compile will only compile if the result is not already available

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -334,6 +334,11 @@ public class Handlebars implements HelperRegistry {
 
   /**
    * Compile the resource located at the given uri.
+   * The implementation uses a cache for previously compiled Templates. By default,
+   * if the resource has been compiled previously, and no changes have occurred
+   * since in the resource, compilation will be skipped and the previously created
+   * Template will be returned. You can set an alternate cache implementation
+   * using {@link #with(TemplateCache cache) with}.
    *
    * @param location The resource's location. Required.
    * @return A compiled template.
@@ -345,6 +350,11 @@ public class Handlebars implements HelperRegistry {
 
   /**
    * Compile the resource located at the given uri.
+   * The implementation uses a cache for previously compiled Templates. By default,
+   * if the resource has been compiled previously, and no changes have occurred
+   * since in the resource, compilation will be skipped and the previously created
+   * Template will be returned. You can set an alternate cache implementation
+   * using {@link #with(TemplateCache cache) with}.
    *
    * @param location The resource's location. Required.
    * @param startDelimiter The start delimiter. Required.
@@ -359,6 +369,10 @@ public class Handlebars implements HelperRegistry {
 
   /**
    * Compile a handlebars template.
+   * The implementation uses a cache for previously compiled Templates. By default,
+   * if same input string has been compiled previously, compilation will be skipped
+   * and the previously created Template will be returned. You can set an alternate
+   * cache implementation using {@link #with(TemplateCache cache) with}.
    *
    * @param input The handlebars input. Required.
    * @return A compiled template.
@@ -370,6 +384,10 @@ public class Handlebars implements HelperRegistry {
 
   /**
    * Compile a handlebars template.
+   * The implementation uses a cache for previously compiled Templates. By default,
+   * if same input string has been compiled previously, compilation will be skipped
+   * and the previously created Template will be returned. You can set an alternate
+   * cache implementation using {@link #with(TemplateCache cache) with}.
    *
    * @param input The input text. Required.
    * @param startDelimiter The start delimiter. Required.
@@ -387,6 +405,11 @@ public class Handlebars implements HelperRegistry {
 
   /**
    * Compile a handlebars template.
+   * The implementation uses a cache for previously compiled Templates. By default,
+   * if the resource has been compiled previously, and no changes have occurred
+   * since in the resource, compilation will be skipped and the previously created
+   * Template will be returned. You can set an alternate cache implementation
+   * using {@link #with(TemplateCache cache) with}.
    *
    * @param source The template source. Required.
    * @return A handlebars template.
@@ -398,6 +421,11 @@ public class Handlebars implements HelperRegistry {
 
   /**
    * Compile a handlebars template.
+   * The implementation uses a cache for previously compiled Templates. By default,
+   * if the resource has been compiled previously, and no changes have occurred
+   * since in the resource, compilation will be skipped and the previously created
+   * Template will be returned. You can set an alternate cache implementation
+   * using {@link #with(TemplateCache cache) with}.
    *
    * @param source The template source. Required.
    * @param startDelimiter The start delimiter. Required.


### PR DESCRIPTION
I believe this is the behavior as implemented, but had to dig through the source to verify. To avoid that the next guy has to do the same thing, this pull request.