### PR TITLE
PathCompiler string literal pattern fails if literal contains leading /

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/PathCompiler.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/PathCompiler.java
@@ -69,7 +69,8 @@ public final class PathCompiler {
 
   /** Split pattern. */
   private static Pattern pattern = Pattern
-      .compile("((\\[[^\\[\\]]+])|(../)|([^" + Pattern.quote(DOT_PATH) + "]+))");
+      .compile("((\\[[^\\[\\]]+])|"
+              + "(" + Pattern.quote(PARENT_PATH) + ")|([^" + Pattern.quote(DOT_PATH) + "]+))");
 
   /**
    * Not allowed.

--- a/handlebars/src/test/java/com/github/jknack/handlebars/PropertyPathParserTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/PropertyPathParserTest.java
@@ -39,6 +39,11 @@ public class PropertyPathParserTest {
     eq(array("foo.bar.baz"), PathCompiler.compile("[foo.bar.baz]"));
     eq(array("foo/bar/baz"), PathCompiler.compile("[foo/bar/baz]"));
     eq(array("foo/bar.baz"), PathCompiler.compile("[foo/bar.baz]"));
+    eq(array("/foo/bar.baz"), PathCompiler.compile("[/foo/bar.baz]"));
+    eq(array("../foo/bar.baz"), PathCompiler.compile("[../foo/bar.baz]"));
+    eq(array("./foo/bar.baz"), PathCompiler.compile("[./foo/bar.baz]"));
+    eq(array("../"), PathCompiler.compile("[../]"));
+    eq(array("./"), PathCompiler.compile("[./]"));
   }
 
   @Test


### PR DESCRIPTION
if the character at position 0 in a string literal is '/', the PathCompiler matches the parent path group instead of the string literal group