### PR TITLE
Render blocks in the parent context and assure a block is passed to templates that use @partial-block

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
@@ -403,6 +403,11 @@ public class Context {
   public static final String PARAM_SIZE = Context.class.getName() + "#paramSize";
 
   /**
+   * Last callee of a partial block. Internal use.
+   */
+  public static final String CALLEE = Context.class.getName() + "#callee";
+
+  /**
    * The parent context. Optional.
    */
   protected Context parent;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -262,6 +262,12 @@ public class Handlebars implements HelperRegistry {
   private boolean prettyPrint;
 
   /**
+   * If true, given partial blocks are not evaluated when defined but when used.
+   * If false, partial blocks are evaluated when defined and used.
+   */
+  private boolean lazyPartialBlockEvaluation;
+
+  /**
    * The helper registry.
    */
   private HelperRegistry registry = new DefaultHelperRegistry();
@@ -739,6 +745,37 @@ public class Handlebars implements HelperRegistry {
   public boolean stringParams() {
     return stringParams;
   }
+
+
+  /**
+   * If true, given partial blocks are not evaluated when defined but when used.
+   * If false, partial blocks are evaluated when defined and used.
+   * @return If true, given partial blocks are not evaluated when defined but when used.
+   *   If false, partial blocks are evaluated when defined and used.
+   */
+  public boolean lazyPartialBlockEvaluation() {
+    return lazyPartialBlockEvaluation;
+  }
+
+
+  /**
+   * If true, given partial blocks are not evaluated when defined but when used.
+   * If false, partial blocks are evaluated when defined and used.
+   */
+  public void setLazyPartialBlockEvaluation(final boolean lazyPartialBlockEvaluation) {
+    this.lazyPartialBlockEvaluation = lazyPartialBlockEvaluation;
+  }
+
+  /**
+   * If true, given partial blocks are not evaluated when defined but when used.
+   * If false, partial blocks are evaluated when defined and used.
+   * @return The handlebars object.
+   */
+  public Handlebars lazyPartialBlockEvaluation(final boolean lazyPartialBlockEvaluation) {
+    setLazyPartialBlockEvaluation(lazyPartialBlockEvaluation);
+    return this;
+  }
+
 
   /**
    * If true, unnecessary spaces and new lines will be removed from output. Default is: false.

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -761,6 +761,7 @@ public class Handlebars implements HelperRegistry {
   /**
    * If true, given partial blocks are not evaluated when defined but when used.
    * If false, partial blocks are evaluated when defined and used.
+   * @param lazyPartialBlockEvaluation Flag to turn it off and on
    */
   public void setLazyPartialBlockEvaluation(final boolean lazyPartialBlockEvaluation) {
     this.lazyPartialBlockEvaluation = lazyPartialBlockEvaluation;
@@ -769,6 +770,7 @@ public class Handlebars implements HelperRegistry {
   /**
    * If true, given partial blocks are not evaluated when defined but when used.
    * If false, partial blocks are evaluated when defined and used.
+   * @param lazyPartialBlockEvaluation Flag to turn it off and on
    * @return The handlebars object.
    */
   public Handlebars lazyPartialBlockEvaluation(final boolean lazyPartialBlockEvaluation) {

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -134,15 +134,18 @@ class Partial extends HelperResolver {
       }
 
       if (this.partial != null) {
+        if (!handlebars.lazyPartialBlockEvaluation()) {
           this.partial.apply(context);
-          inlineTemplates.put("@partial-block",
-                new PartialBlockForwardingTemplate(this,
-                        this.partial,
-                        inlineTemplates.get("@partial-block"),
-                        callee,
-                        handlebars
-                )
-          );
+        }
+
+        inlineTemplates.put("@partial-block",
+            new PartialBlockForwardingTemplate(this,
+              this.partial,
+              inlineTemplates.get("@partial-block"),
+              callee,
+              handlebars
+            )
+        );
       }
 
       Template template = inlineTemplates.get(path);

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -92,7 +92,7 @@ class Partial extends HelperResolver {
    * @param hash Template params
    */
   public Partial(final Handlebars handlebars, final Template path, final String context,
-                 final Map<String, Param> hash) {
+      final Map<String, Param> hash) {
     super(handlebars);
     this.path = notNull(path, "The path is required.");
     this.context = context;
@@ -115,13 +115,13 @@ class Partial extends HelperResolver {
 
   @Override
   protected void merge(final Context context, final Writer writer)
-          throws IOException {
+      throws IOException {
     try {
       String path = this.path.apply(context);
       /** Inline partial? */
       LinkedList<Map<String, Template>> partials = context.data(Context.INLINE_PARTIALS);
       Map<String, Template> inlineTemplates = partials.getLast();
-      Template callee = context.data("callee");
+      Template callee = context.data(Context.CALLEE);
 
       final boolean pathIsPartialBlock = "@partial-block".equals(path);
       final Template lastPartialBlock = inlineTemplates.get("@partial-block");
@@ -150,7 +150,6 @@ class Partial extends HelperResolver {
 
       Template template = inlineTemplates.get(path);
 
-
       if (template == null) {
         LinkedList<TemplateSource> invocationStack = context.data(Context.INVOCATION_STACK);
 
@@ -165,20 +164,18 @@ class Partial extends HelperResolver {
             final String reason;
             if (invocationStack.isEmpty()) {
               reason = String.format("infinite loop detected, partial '%s' is calling itself",
-                      source.filename());
+                  source.filename());
 
               message = String.format("%s:%s:%s: %s", caller.filename(), line, column, reason);
             } else {
               reason = String.format(
-                      "infinite loop detected, partial '%s' was previously loaded",
-                      source.filename()
-              );
+                  "infinite loop detected, partial '%s' was previously loaded", source.filename());
 
               message = String.format("%s:%s:%s: %s\n%s", caller.filename(), line, column, reason,
-                      "at " + join(invocationStack, "\nat "));
+                  "at " + join(invocationStack, "\nat "));
             }
             HandlebarsError error = new HandlebarsError(caller.filename(), line,
-                    column, reason, text(), message);
+                column, reason, text(), message);
             throw new HandlebarsException(error);
           }
 
@@ -196,10 +193,10 @@ class Partial extends HelperResolver {
         }
 
       }
-      context.data("callee", this);
+      context.data(Context.CALLEE, this);
       Context ctx = Context.newPartialContext(context, this.scontext, hash(context));
       template.apply(ctx, writer);
-      context.data("callee", callee);
+      context.data(Context.CALLEE, callee);
     } catch (IOException ex) {
       String reason = String.format("The partial '%s' at '%s' could not be found",
               loader.resolve(path.text()), ex.getMessage());
@@ -235,7 +232,7 @@ class Partial extends HelperResolver {
    * @return True, if the file was already processed.
    */
   private static boolean exists(final List<TemplateSource> invocationStack,
-                                final String filename) {
+      final String filename) {
     for (TemplateSource ts : invocationStack) {
       if (ts.filename().equals(filename)) {
         return true;
@@ -312,8 +309,8 @@ class Partial extends HelperResolver {
   public String text() {
     String path = this.path.text();
     StringBuilder buffer = new StringBuilder(startDelimiter)
-            .append('>')
-            .append(path);
+        .append('>')
+        .append(path);
 
     if (context != null) {
       buffer.append(' ').append(context);
@@ -323,7 +320,7 @@ class Partial extends HelperResolver {
 
     if (this.partial != null) {
       buffer.append(this.partial.text()).append(startDelimiter, 0, startDelimiter.length() - 1)
-              .append("/").append(path).append(endDelimiter);
+          .append("/").append(path).append(endDelimiter);
     }
     return buffer.toString();
   }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -123,8 +123,14 @@ class Partial extends HelperResolver {
       Map<String, Template> inlineTemplates = partials.getLast();
       Template callee = context.data("callee");
 
-      if("@partial-block".equals(path) && !isCalleeOf(callee, inlineTemplates.get("@partial-block"))) {
-        throw new IllegalArgumentException(callee + " does not provide a @partial-block for " + this);
+      final boolean pathIsPartialBlock = "@partial-block".equals(path);
+      final Template lastPartialBlock = inlineTemplates.get("@partial-block");
+      final boolean parentIsNotLastPartialBlock = !isCalleeOf(callee, lastPartialBlock);
+
+      if (pathIsPartialBlock && parentIsNotLastPartialBlock) {
+        throw new IllegalArgumentException(
+                callee + " does not provide a @partial-block for " + this
+        );
       }
 
       if (this.partial != null) {
@@ -194,12 +200,17 @@ class Partial extends HelperResolver {
     }
   }
 
-  private boolean isCalleeOf(Template callee, Template partialBlock) {
-    if(callee == null || partialBlock == null) {
+  /**
+   * @param callee parent template of the currently traversed template
+   * @param partialBlock partial block candidate
+   * @return returns if callee and partialBlock are the same
+   */
+  private boolean isCalleeOf(final Template callee, final Template partialBlock) {
+    if (callee == null || partialBlock == null) {
       return false;
     }
 
-    if(!callee.filename().equalsIgnoreCase(partialBlock.filename())) {
+    if (!callee.filename().equalsIgnoreCase(partialBlock.filename())) {
       return false;
     }
 

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -134,14 +134,15 @@ class Partial extends HelperResolver {
       }
 
       if (this.partial != null) {
-        inlineTemplates.put("@partial-block",
+          this.partial.apply(context);
+          inlineTemplates.put("@partial-block",
                 new PartialBlockForwardingTemplate(this,
                         this.partial,
                         inlineTemplates.get("@partial-block"),
                         callee,
                         handlebars
                 )
-        );
+          );
       }
 
       Template template = inlineTemplates.get(path);

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Partial.java
@@ -199,10 +199,10 @@ class Partial extends HelperResolver {
       context.data(Context.CALLEE, callee);
     } catch (IOException ex) {
       String reason = String.format("The partial '%s' at '%s' could not be found",
-              loader.resolve(path.text()), ex.getMessage());
+          loader.resolve(path.text()), ex.getMessage());
       String message = String.format("%s:%s:%s: %s", filename, line, column, reason);
       HandlebarsError error = new HandlebarsError(filename, line,
-              column, reason, text(), message);
+          column, reason, text(), message);
       throw new HandlebarsException(error);
     }
   }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/PartialBlockForwardingTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/PartialBlockForwardingTemplate.java
@@ -1,3 +1,20 @@
+/**
+ * Copyright (c) 2012-2015 Edgar Espina
+ *
+ * This file is part of Handlebars.java.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.jknack.handlebars.internal;
 
 import com.github.jknack.handlebars.Context;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/PartialBlockForwardingTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/PartialBlockForwardingTemplate.java
@@ -1,0 +1,80 @@
+package com.github.jknack.handlebars.internal;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ *
+ */
+public class PartialBlockForwardingTemplate extends BaseTemplate {
+    /**
+     * The block to be passed as partial-block.
+     */
+    private final Template block;
+
+    /**
+     * The previous partial-block definition of the template which contains this partial.
+     */
+    private final Template parentPartialBlock;
+
+    /**
+     * The callee of the parent partial.
+     */
+    private final Template callee;
+
+    /**
+     * Constructs a PartialBlockForwardingTemplate.
+     *
+     * @param parent the parent partial
+     * @param block the block to be passed as partial-block.
+     * @param parentPartialBlock the previous partial-block definition of
+     *                          the template which contains this partial.
+     * @param callee the template that renders the parent
+     * @param handlebars handlebars
+     */
+    public PartialBlockForwardingTemplate(
+            final Template parent,
+            final Template block,
+            final Template parentPartialBlock,
+            final Template callee,
+            final Handlebars handlebars
+    ) {
+        super(handlebars);
+        this.block = block;
+        this.parentPartialBlock = parentPartialBlock;
+        this.callee = callee;
+        this.filename(block.filename());
+        this.position(parent.position()[0], parent.position()[1]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void merge(final Context context, final Writer writer) throws IOException {
+        LinkedList<Map<String, Template>> partials = context.data(Context.INLINE_PARTIALS);
+        Map<String, Template> inlineTemplates = partials.getLast();
+        Template oldPartialBlock = inlineTemplates.get("@partial-block");
+        Template oldCallee = context.data("callee");
+
+        context.data("callee", callee);
+        inlineTemplates.put("@partial-block", parentPartialBlock);
+        block.apply(context, writer);
+        inlineTemplates.put("@partial-block", oldPartialBlock);
+        context.data("callee", oldCallee);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String text() {
+        return block.text();
+    }
+}

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/PartialBlockForwardingTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/PartialBlockForwardingTemplate.java
@@ -78,13 +78,13 @@ public class PartialBlockForwardingTemplate extends BaseTemplate {
         LinkedList<Map<String, Template>> partials = context.data(Context.INLINE_PARTIALS);
         Map<String, Template> inlineTemplates = partials.getLast();
         Template oldPartialBlock = inlineTemplates.get("@partial-block");
-        Template oldCallee = context.data("callee");
+        Template oldCallee = context.data(Context.CALLEE);
 
-        context.data("callee", callee);
+        context.data(Context.CALLEE, callee);
         inlineTemplates.put("@partial-block", parentPartialBlock);
         block.apply(context, writer);
         inlineTemplates.put("@partial-block", oldPartialBlock);
-        context.data("callee", oldCallee);
+        context.data(Context.CALLEE, oldCallee);
     }
 
     /**

--- a/handlebars/src/test/java/com/github/jknack/handlebars/LazyPartialBlockEvaluationTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/LazyPartialBlockEvaluationTest.java
@@ -1,0 +1,32 @@
+package com.github.jknack.handlebars;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class LazyPartialBlockEvaluationTest extends AbstractTest {
+    @Override
+    protected void configure(Handlebars handlebars) {
+        handlebars.setLazyPartialBlockEvaluation(true);
+    }
+
+    @Test
+    public void shouldSupportMultipleLevelsOfNestedPartialBlocks() throws IOException {
+        String myMoreNestedPartial = "I{{> @partial-block}}I";
+        String myNestedPartial = "A{{#> myMoreNestedPartial}}{{> @partial-block}}{{/myMoreNestedPartial}}B";
+        String myPartial = "{{#> myNestedPartial}}{{> @partial-block}}{{/myNestedPartial}}";
+        Template t = compile("C{{#> myPartial}}hello{{/myPartial}}D", new Hash(), $("myPartial", myPartial, "myNestedPartial", myNestedPartial,"myMoreNestedPartial", myMoreNestedPartial));
+        String result = t.apply(null);
+        assertEquals("'CAIhelloIBD' should === '" + result + "': ", "CAIhelloIBD", result);
+    }
+
+    @Test(expected = HandlebarsException.class)
+    public void shouldNotDefineInlinePartialsInPartialBlockCall() throws IOException {
+        // myPartial should not be defined and thus throw a handlebars exception
+        shouldCompileToWithPartials(
+                "{{#> dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",
+                $, $("dude", "{{> myPartial }}"), "");
+    }
+}

--- a/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/PartialBlockTest.java
@@ -8,6 +8,11 @@ import org.junit.Test;
 
 public class PartialBlockTest extends AbstractTest {
 
+  @Override
+  protected Handlebars newHandlebars() {
+    return super.newHandlebars().lazyPartialBlockEvaluation(false);
+  }
+
   @Test
   public void text() throws IOException {
     assertEquals("{{#>dude}}{{#*inline \"myPartial\"}}success{{/inline}}{{/dude}}",


### PR DESCRIPTION
We heavily use `@partial-block` in our project context. We noticed the following flaws with the current evaluation of partial-blocks in handlebars.java:

* If a partial provides a block, it is currently evaluated twice. We added an option to only lazy evaluate the partial to improve performance.
* Currently the implementation of `@partial-block` throws a stack overflow error (infinite recursion), when a block of a partial provides a template which also contains `@partial-block` (see example below). This is fixed by this pull request. Handlebars.js also supports this, see https://github.com/wycats/handlebars.js/pull/1290
* In order to protect against the case when a partial-block is required but not provided, we introduced the `callee`. It is used to check whether the last provided partial-block is the right partial block for the given call to `{{> @partial-block}}`.

stack overflow example:
```hbs
{{!-- page.hbs --}}
{{#> special-button}}
  Lorem ipsum
{{/special-button}}

{{!-- special-button.hbs --}}
{{#> generic-button}}
  {{> @partial-block}}
{{/generic-button}}

{{!-- generic-button.hbs --}}
<button>
  {{> @partial-block}}
</button>
```

