### PR TITLE
Changing access modifiers to enable extensibility of HandlebarsViewResolver

### DIFF
--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsView.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsView.java
@@ -83,7 +83,7 @@ public class HandlebarsView extends AbstractTemplateView {
    *
    * @param template The compiled template. Required.
    */
-  void setTemplate(final Template template) {
+  public void setTemplate(final Template template) {
     this.template = requireNonNull(template, "A handlebars template is required.");
   }
 
@@ -92,7 +92,7 @@ public class HandlebarsView extends AbstractTemplateView {
    *
    * @param valueResolvers The value resolvers. Required.
    */
-  void setValueResolver(final ValueResolver... valueResolvers) {
+  public void setValueResolver(final ValueResolver... valueResolvers) {
     this.valueResolvers = requireNonNull(valueResolvers,
         "At least one value-resolver must be present.");
   }

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -329,6 +329,13 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
   }
 
   /**
+   * @return The array of resolvers.
+   */
+  protected ValueResolver[] getValueResolvers() {
+    return this.valueResolvers;
+  }
+
+  /**
    * Set the value resolvers.
    *
    * @param valueResolvers The value resolvers. Required.


### PR DESCRIPTION
See:
https://github.com/jknack/handlebars.java/issues/638

This allows one to do something like:
```
 @Override
    protected AbstractUrlBasedView configure(HandlebarsView view) throws IOException {
        String url = view.getUrl();
        url = url.substring(this.getPrefix().length(), url.length() - this.getSuffix().length());
        try {
            String rawTemplate = getTemplateFromApi();
            view.setTemplate(this.handlebars.compileInline(rawTemplate));
            view.setValueResolver(this.getValueResolvers());
        } catch (IOException e) {
            this.logger.debug("File not found: " + url);
        }
        return view;
    }
```