### PR TITLE
Update FormatterChain.java

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/FormatterChain.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/FormatterChain.java
@@ -61,10 +61,14 @@ public class FormatterChain implements Formatter.Chain {
    * Gets the next formatter in the chain.
    * @return The formatter at the next index.
    */
-  private FormatterChain next() {
-    return new FormatterChain(chain, index + 1);
+  private Formatter.Chain next() {
+    if (index < chain.size()) {
+      return new FormatterChain(chain, index + 1);
+    } else {
+      return Formatter.NOOP;
+    }
   }
-
+  
   @Override
   public Object format(final Object value) {
     Object output;


### PR DESCRIPTION
Fix "index out of bounds" exception when calling `chain.format(o)` in Formatter implementation.

The next-method doesn't check the size of the formatter list at the moment.
This change just returns Formatter.NOOP when the end of the list is reached.