### PR TITLE
Fix compilation of templates with windows newlines (#664)

### DIFF
--- a/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
+++ b/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
@@ -333,7 +333,7 @@ ID
 fragment
 ID_START
   :
-   [a-zA-ZА-Яа-я_$@:\u0001-\u0009\u000b-\u001E\u00C0-\u00FF]
+   [a-zA-ZА-Яа-я_$@:\u0001-\u0009\u000b\u000c\u000e-\u001E\u00C0-\u00FF]
   ;
 
 fragment

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i664/Issue664.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i664/Issue664.java
@@ -1,0 +1,21 @@
+package com.github.jknack.handlebars.i664;
+
+
+import com.github.jknack.handlebars.AbstractTest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue664 extends AbstractTest {
+
+    // Windows newline "\r\n" should not cause problems during compilation of templates
+    @Test
+    public void windowsNewlineShouldNotCauseErrors() throws IOException {
+        assertEquals("{{#if value}}true{{else}}false{{/if}}",
+                compile("{{#if\r\nvalue}}true{{else}}false{{/if}}").text());
+
+       }
+
+}


### PR DESCRIPTION
Fix for issue #664 Windows newlines break template compilation