### PR TITLE
doc typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Example:
 or if you prefer YAML **myTemplates/home.yml**:
 
 ```yml
-list:
+items:
   - name: Handlebars.java rocks!
 ```
 


### PR DESCRIPTION
Looks like this should be `items` instead of `list`