### PR TITLE
Add length to collections (list, set)

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/JavaBeanValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/JavaBeanValueResolver.java
@@ -1,14 +1,14 @@
 /**
  * Copyright (c) 2012-2015 Edgar Espina
- *
+ * <p>
  * This file is part of Handlebars.java.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,7 @@
 package com.github.jknack.handlebars.context;
 
 import java.lang.reflect.Method;
+import java.util.Collection;
 
 import com.github.jknack.handlebars.ValueResolver;
 
@@ -29,60 +30,90 @@ import com.github.jknack.handlebars.ValueResolver;
  */
 public class JavaBeanValueResolver extends MethodValueResolver {
 
-  /**
-   * The 'is' prefix.
-   */
-  private static final String IS_PREFIX = "is";
+    /**
+     * The 'is' prefix.
+     */
+    private static final String IS_PREFIX = "is";
 
-  /**
-   * The 'get' prefix.
-   */
-  private static final String GET_PREFIX = "get";
+    /**
+     * The 'get' prefix.
+     */
+    private static final String GET_PREFIX = "get";
 
-  /**
-   * The default value resolver.
-   */
-  public static final ValueResolver INSTANCE = new JavaBeanValueResolver();
+    /**
+     * The default value resolver.
+     */
+    public static final ValueResolver INSTANCE = new JavaBeanValueResolver();
 
-  @Override
-  public boolean matches(final Method method, final String name) {
-    boolean isStatic = isStatic(method);
-    boolean isPublic = isPublic(method);
-    boolean isGet = method.getName().equals(javaBeanMethod(GET_PREFIX, name));
-    boolean isBoolGet = method.getName().equals(javaBeanMethod(IS_PREFIX, name));
-    int parameterCount = method.getParameterTypes().length;
+    @Override
+    public boolean matches(final Method method, final String name) {
+        if (method.getName().equals("size") && name.equals("length")) {
+            boolean isCollection = isCollectionMethod(method);
+            if (isCollection) {
+                return true;
+            }
+        }
 
-    return !isStatic && isPublic && parameterCount == 0 && (isGet || isBoolGet);
-  }
+        boolean isStatic = isStatic(method);
+        boolean isPublic = isPublic(method);
+        boolean isGet = method.getName().equals(javaBeanMethod(GET_PREFIX, name));
+        boolean isBoolGet = method.getName().equals(javaBeanMethod(IS_PREFIX, name));
+        int parameterCount = method.getParameterTypes().length;
 
-  /**
-   * Convert the property's name to a JavaBean read method name.
-   *
-   * @param prefix The prefix: 'get' or 'is'.
-   * @param name The unqualified property name.
-   * @return The javaBean method name.
-   */
-  private static String javaBeanMethod(final String prefix,
-      final String name) {
-    StringBuilder buffer = new StringBuilder(prefix);
-    buffer.append(name);
-    buffer.setCharAt(prefix.length(), Character.toUpperCase(name.charAt(0)));
-    return buffer.toString();
-  }
-
-  @Override
-  protected String memberName(final Method member) {
-    String name = member.getName();
-    if (name.startsWith(GET_PREFIX)) {
-      name = name.substring(GET_PREFIX.length());
-    } else if (name.startsWith(IS_PREFIX)) {
-      name = name.substring(IS_PREFIX.length());
-    } else {
-      return name;
+        return !isStatic && isPublic && parameterCount == 0 && (isGet || isBoolGet);
     }
-    if (name.length() > 0) {
-      return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+
+    /**
+     * Convert the property's name to a JavaBean read method name.
+     *
+     * @param prefix The prefix: 'get' or 'is'.
+     * @param name   The unqualified property name.
+     * @return The javaBean method name.
+     */
+    private static String javaBeanMethod(final String prefix,
+                                         final String name) {
+        StringBuilder buffer = new StringBuilder(prefix);
+        buffer.append(name);
+        buffer.setCharAt(prefix.length(), Character.toUpperCase(name.charAt(0)));
+        return buffer.toString();
     }
-    return member.getName();
-  }
+
+    @Override
+    protected String memberName(final Method member) {
+        if (member.getName().equals("size")) {
+            boolean isCollection = isCollectionMethod(member);
+
+            if (isCollection) {
+                return "length";
+            }
+        }
+
+        String name = member.getName();
+        if (name.startsWith(GET_PREFIX)) {
+            name = name.substring(GET_PREFIX.length());
+        } else if (name.startsWith(IS_PREFIX)) {
+            name = name.substring(IS_PREFIX.length());
+        } else {
+            return name;
+        }
+        if (name.length() > 0) {
+            return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+        }
+        return member.getName();
+    }
+
+    /**
+     * Check is method class implements Collection interface.
+     *
+     * @param method from class
+     * @return true/false
+     */
+    private boolean isCollectionMethod(final Method method) {
+        for (Class clazz : method.getDeclaringClass().getInterfaces()) {
+            if (Collection.class.equals(clazz)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/CollectionsLengthTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/CollectionsLengthTest.java
@@ -1,0 +1,48 @@
+package com.github.jknack.handlebars;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionsLengthTest extends AbstractTest {
+
+    static class SizeAndLength {
+        int size;
+        int length;
+
+        public int getSize() {
+            return size;
+        }
+
+        public void setSize(int size) {
+            this.size = size;
+        }
+
+        public int getLength() {
+            return length;
+        }
+
+        public void setLength(int length) {
+            this.length = length;
+        }
+    }
+
+    @Test
+    public void collectionLengthTest() throws IOException {
+        List<String> list = new ArrayList<>();
+        list.add("a");
+        shouldCompileTo("{{this.length}}", list, "1");
+    }
+
+    @Test
+    public void otherClassSizeAndLength() throws IOException {
+        SizeAndLength sizeAndLength = new SizeAndLength();
+        sizeAndLength.length = 5;
+        sizeAndLength.size = 4;
+        shouldCompileTo("{{this.length}}", sizeAndLength, "5");
+        shouldCompileTo("{{this.size}}", sizeAndLength, "4");
+
+    }
+}


### PR DESCRIPTION
In java handlebars we can't resolve Collection::length as in javascript, because java collection interface didn't has getLength or isLength method.
This code-crutch is temporary solving of this problem.
In my project I use my own Resolver class, that extends JavaBeanResolver and do same (as in pull request).