### PR TITLE
Allow the formatter to emit a SafeString to opt out of escaping. 

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
@@ -238,11 +238,13 @@ class Variable extends HelperResolver {
    * @return Formatted and escaped value.
    */
   protected CharSequence formatAndEscape(final Object value, final Formatter.Chain formatter) {
-    CharSequence formatted = formatter.format(value).toString();
-    if (value instanceof Handlebars.SafeString) {
-      return formatted;
+    Object formatted = formatter.format(value);
+    CharSequence formattedString = formatted.toString();
+    if (formatted instanceof Handlebars.SafeString) {
+        return formattedString;
     }
-    return escapingStrategy.escape(formatted);
+    CharSequence escapedString = escapingStrategy.escape(formattedString);
+    return escapedString;
   }
 
   @Override

--- a/handlebars/src/test/java/com/github/jknack/handlebars/Issue682.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/Issue682.java
@@ -1,0 +1,21 @@
+package com.github.jknack.handlebars;
+
+import static org.junit.Assert.assertEquals;
+import java.io.IOException;
+import org.junit.Test;
+
+public class Issue682 extends AbstractTest {
+  @Override
+  protected void configure(final Handlebars handlebars) {
+    handlebars.with((value, chain) -> {
+        return new Handlebars.SafeString(value.toString());
+    });
+  }
+
+  @Test
+  public void dowork() throws IOException {
+    Template t = compile("{{this}}");
+    // the formatter (wrongly) trusts all values in the context but proves that it's working
+    assertEquals("as\"df", t.apply("as\"df"));
+  }
+}


### PR DESCRIPTION
fix for #682