### PR TITLE
Allow carriage return and tabs.

### DIFF
--- a/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
+++ b/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
@@ -333,7 +333,7 @@ ID
 fragment
 ID_START
   :
-   [a-zA-ZА-Яа-я_$@:\u0001-\u0009\u000b-\u001E\u00C0-\u00FF]
+   [a-zA-ZА-Яа-я_$@:\u0001-\u0008\u000B\u000C\u000E-\u001E\u00C0-\u00FF]
   ;
 
 fragment

--- a/handlebars/src/test/java/com/github/jknack/handlebars/internal/HbsParserTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/internal/HbsParserTest.java
@@ -1,9 +1,12 @@
 package com.github.jknack.handlebars.internal;
 
+import static org.junit.Assert.assertEquals;
+
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class HbsParserTest {
@@ -116,6 +119,21 @@ public class HbsParserTest {
     parse("{{=<% %>=}}<%hello%><%={{ }}=%>{{reset}}");
     parse("{{= | | =}}<|#lambda|-|/lambda|>");
     parse("{{=+-+ +-+=}}+-+test+-+");
+  }
+
+  @Test
+  public void whiteSpaceHandledEqually() {
+    String withSpace = "{{helper param1=\"1\" param2=2}}";
+    ParseTree tree = parse(withSpace);
+
+    String withNewlines = "{{helper\nparam1=\"1\"\nparam2=2}}";
+    assertEquals("Newlines should be treated the same as spaces", tree.getText(), parse(withNewlines).getText());
+
+    String withDosNewlines = "{{helper\r\nparam1=\"1\"\r\nparam2=2}}";
+    assertEquals("DOS-style newlines should be treated the same as spaces", tree.getText(), parse(withDosNewlines).getText());
+
+    String alignedWithTabs = "{{helper\n\tparam1=\"1\"\n\tparam2=2}}";
+    assertEquals("Tab-aligned variables should be treated the same as spaces", tree.getText(), parse(alignedWithTabs).getText());
   }
 
   private ParseTree parse(final String input) {


### PR DESCRIPTION
After upgrading handlebars, some of our templates stopped working.
We tracked it down to carriage returns and tabs being part of identifiers now.

This led to some helpers not working anymore, for instance:
```
{{helper param1="something"
<tab><tab>param2="something else"}}
```

This change fixes that (and adds a test to check that the parse tree of various ways to format this are the same).
