### PR TITLE
Removed unused dependency

### DIFF
--- a/handlebars-markdown/pom.xml
+++ b/handlebars-markdown/pom.xml
@@ -46,12 +46,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <optional>true</optional>
-    </dependency>
-
   </dependencies>
 
 </project>


### PR DESCRIPTION
Hello, I noticed that dependency `commons-lang3` was added https://github.com/jknack/handlebars.java/commit/913673f96623d1a2f52b9ea780b85510bf1b9d3f  to the module `handlebars-markdown`, but it is not used. Hence, it can be safely removed to make the `pom` clearer :)


