### PR TITLE
Fix issue with NPE script engine on Java 11

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -1456,7 +1456,7 @@ public class Handlebars implements HelperRegistry {
     synchronized (this) {
       if (this.engine == null) {
 
-        this.engine = new ScriptEngineManager().getEngineByName("nashorn");
+        this.engine = new ScriptEngineManager(null).getEngineByName("nashorn");
 
         Throwing.run(() -> engine.eval(Files.read(this.handlebarsJsFile, charset)));
       }


### PR DESCRIPTION
If loader is null, the script engine factories that are bundled with the platform and that are in the usual extension directories (installed extensions) are loaded.
Fixes #702