### PR TITLE
Add @HelperFunction annotation for overriding method names from Helper Sources (#829)

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/DefaultHelperRegistry.java
@@ -234,10 +234,11 @@ public class DefaultHelperRegistry implements HelperRegistry {
       Method[] methods = clazz.getDeclaredMethods();
       for (Method method : methods) {
         boolean isPublic = Modifier.isPublic(method.getModifiers());
-        String helperName = method.getName();
         if (isPublic) {
           boolean isStatic = Modifier.isStatic(method.getModifiers());
           if (source != null || isStatic) {
+            HelperFunction annotation = method.getAnnotation(HelperFunction.class);
+            String helperName = annotation != null ? annotation.value() : method.getName();
             isTrue(overloaded.add(helperName), "name conflict found: " + helperName);
             registerHelper(helperName, new MethodHelper(method, source));
           }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/HelperFunction.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/HelperFunction.java
@@ -1,0 +1,18 @@
+package com.github.jknack.handlebars.helper;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Decorates a method that represents a helper function extracted via a "helper source"
+ * with metadata that cannot be inferred from its signature, such as a custom helper name.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HelperFunction {
+
+    /**
+     * The name used to invoke the decorated helper function in a handlebars template.
+     */
+    String value();
+
+}

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ReflectiveHelperTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ReflectiveHelperTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
+import com.github.jknack.handlebars.helper.HelperFunction;
 import org.junit.Test;
 
 import com.github.jknack.handlebars.Handlebars.SafeString;
@@ -51,6 +52,11 @@ public class ReflectiveHelperTest extends AbstractTest {
   public void testHelperWithParamsAndOptions() throws IOException {
     shouldCompileTo("{{helperWithParamsAndOptions \"string\" true 4}}", $,
         "helperWithParamsAndOptions:string:true:4");
+  }
+
+  @Test
+  public void testAnnotatedHelper() throws IOException {
+    shouldCompileTo("{{this-is-annotated}}", null, "i am an annotated helper function");
   }
 
   @Test
@@ -153,6 +159,11 @@ public class ReflectiveHelperTest extends AbstractTest {
       final Options options) {
     assertNotNull(options);
     return new SafeString(String.format("helperWithParamsAndOptions:%s:%s:%s", context, p0, p1));
+  }
+
+  @HelperFunction("this-is-annotated")
+  public CharSequence annotatedHelper() {
+    return "i am an annotated helper function";
   }
 
   public CharSequence blog(final Blog blog, final Options options) {


### PR DESCRIPTION
This resolves #829 by adding a `@HelperFunction` annotation as described in the issue. I added a test to ensure that the override works as expected when applied.