### PR TITLE
Upgrade to latest handlebars.js (4.7.7)

### DIFF
--- a/handlebars-maven-plugin/src/main/java/com/github/jknack/handlebars/maven/PrecompilePlugin.java
+++ b/handlebars-maven-plugin/src/main/java/com/github/jknack/handlebars/maven/PrecompilePlugin.java
@@ -113,7 +113,7 @@ public class PrecompilePlugin extends HandlebarsPlugin {
   /**
    * The handlebars js file.
    */
-  @Parameter(defaultValue = "/handlebars-v4.7.6.js")
+  @Parameter(defaultValue = "/handlebars-v4.7.7.js")
   private String handlebarsJsFile;
 
   /**

--- a/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue234.java
+++ b/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue234.java
@@ -24,7 +24,7 @@ public class Issue234 {
     plugin.addTemplate("c");
     plugin.setAmd(true);
     plugin.setProject(newProject());
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
 

--- a/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/PrecompilePluginTest.java
+++ b/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/PrecompilePluginTest.java
@@ -27,7 +27,7 @@ public class PrecompilePluginTest {
     plugin.setSuffix(".html");
     plugin.setOutput("target/helpers-i18njs.js");
     plugin.setProject(newProject());
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
 
@@ -45,7 +45,7 @@ public class PrecompilePluginTest {
     plugin.addTemplate("a");
     plugin.addTemplate("c");
     plugin.setProject(newProject());
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
 
@@ -61,7 +61,7 @@ public class PrecompilePluginTest {
     plugin.setSuffix(".html");
     plugin.setOutput("target/newdir/helpers.js");
     plugin.setProject(newProject());
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
   }
@@ -73,7 +73,7 @@ public class PrecompilePluginTest {
     plugin.setSuffix(".html");
     plugin.setOutput("target/missing-helpers.js");
     plugin.setProject(newProject());
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
   }
@@ -85,7 +85,7 @@ public class PrecompilePluginTest {
     plugin.setSuffix(".html");
     plugin.setOutput("target/no-helpers.js");
     plugin.setProject(newProject());
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
 
@@ -127,7 +127,7 @@ public class PrecompilePluginTest {
     plugin.setSuffix(".html");
     plugin.setOutput("target/no-helpers.js");
     plugin.setProject(project);
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
   }
@@ -139,7 +139,7 @@ public class PrecompilePluginTest {
     withoutRT.setSuffix(".html");
     withoutRT.setOutput("target/without-rt-helpers.js");
     withoutRT.setProject(newProject());
-    withoutRT.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    withoutRT.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     withoutRT.execute();
 
@@ -149,7 +149,7 @@ public class PrecompilePluginTest {
     withRT.setOutput("target/with-rt-helpers.js");
     withRT.setRuntime("src/test/resources/handlebars.runtime.js");
     withRT.setProject(newProject());
-    withRT.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    withRT.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     withRT.execute();
 
@@ -165,7 +165,7 @@ public class PrecompilePluginTest {
     withoutRT.setSuffix(".html");
     withoutRT.setOutput("target/helpers-normal.js");
     withoutRT.setProject(newProject());
-    withoutRT.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    withoutRT.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     withoutRT.execute();
 
@@ -175,7 +175,7 @@ public class PrecompilePluginTest {
     withRT.setOutput("target/helpers.min.js");
     withRT.setMinimize(true);
     withRT.setProject(newProject());
-    withRT.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    withRT.setHandlebarsJsFile("/handlebars-v4.7.7.js");
     withRT.execute();
 
     assertTrue("Normal file must be larger than minimized",
@@ -190,7 +190,7 @@ public class PrecompilePluginTest {
     plugin.setSuffix(".html");
     plugin.setOutput("target/helpers.js");
     plugin.setProject(newProject());
-    plugin.setHandlebarsJsFile("/handlebars-v4.7.6.js");
+    plugin.setHandlebarsJsFile("/handlebars-v4.7.7.js");
 
     plugin.execute();
 

--- a/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
+++ b/handlebars-springmvc/src/main/java/com/github/jknack/handlebars/springmvc/HandlebarsViewResolver.java
@@ -371,10 +371,10 @@ public class HandlebarsViewResolver extends AbstractTemplateViewResolver
    *
    * <pre>
    *   Handlebars handlebars = new Handlebars()
-   *      .handlebarsJsFile("handlebars-v4.7.6.js");
+   *      .handlebarsJsFile("handlebars-v4.7.7.js");
    * </pre>
    *
-   * Default handlebars.js is <code>handlebars-v4.7.6.js</code>.
+   * Default handlebars.js is <code>handlebars-v4.7.7.js</code>.
    *
    * @param location A classpath location of the handlebar.js file.
    */

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -313,7 +313,7 @@ public class Handlebars implements HelperRegistry {
   private String endDelimiter = DELIM_END;
 
   /** Location of the handlebars.js file. */
-  private String handlebarsJsFile = "/handlebars-v4.7.6.js";
+  private String handlebarsJsFile = "/handlebars-v4.7.7.js";
 
   /** List of formatters. */
   private List<Formatter> formatters = new ArrayList<>();

--- a/handlebars/src/main/resources/handlebars-v4.7.7.js
+++ b/handlebars/src/main/resources/handlebars-v4.7.7.js
@@ -1,7 +1,7 @@
 /**!
 
  @license
- handlebars v4.7.6
+ handlebars v4.7.7
 
 Copyright (C) 2011-2019 by Yehuda Katz
 
@@ -278,7 +278,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _internalProtoAccess = __webpack_require__(33);
 
-	var VERSION = '4.7.6';
+	var VERSION = '4.7.7';
 	exports.VERSION = VERSION;
 	var COMPILER_REVISION = 8;
 	exports.COMPILER_REVISION = COMPILER_REVISION;
@@ -1525,7 +1525,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          loc: loc
 	        });
 	      }
-	      return obj[name];
+	      return container.lookupProperty(obj, name);
 	    },
 	    lookupProperty: function lookupProperty(parent, propertyName) {
 	      var result = parent[propertyName];
@@ -3903,7 +3903,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return this.internalNameLookup(parent, name);
 	  },
 	  depthedLookup: function depthedLookup(name) {
-	    return [this.aliasable('container.lookup'), '(depths, "', name, '")'];
+	    return [this.aliasable('container.lookup'), '(depths, ', JSON.stringify(name), ')'];
 	  },
 
 	  compilerInfo: function compilerInfo() {

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i417/Issue417.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i417/Issue417.java
@@ -25,7 +25,7 @@ public class Issue417 extends AbstractTest {
             + "  return \"Hi \"\n"
             + "    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,\"var\") || (depth0 != null ? lookupProperty(depth0,\"var\") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === \"function\" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{\"name\":\"var\",\"hash\":{},\"data\":data,\"loc\":{\"start\":{\"line\":1,\"column\":3},\"end\":{\"line\":1,\"column\":10}}}) : helper)))\n"
             + "    + \"!\";\n"
-            + "},\"useData\":true}", new Handlebars().handlebarsJsFile("/handlebars-v4.7.6.js")
+            + "},\"useData\":true}", new Handlebars().handlebarsJsFile("/handlebars-v4.7.7.js")
             .compileInline("Hi {{var}}!").toJavaScript());
   }
 


### PR DESCRIPTION
Fixes #848. There's a critical vulnerability in handlebars.js < 4.7.7, so it's important that we upgrade the Java library/publish a new version as soon as possible.

`mvn clean install` succeeds.