### PR TITLE
Add includeZero on if-helper

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/IfHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/IfHelper.java
@@ -47,7 +47,15 @@ public class IfHelper implements Helper<Object> {
   public Object apply(final Object context, final Options options)
       throws IOException {
     Buffer buffer = options.buffer();
-    if (options.isFalsy(context)) {
+
+    boolean isFalsy = options.isFalsy(context);
+    boolean includeZero = options.hash("includeZero", false);
+
+    if (context instanceof Number && includeZero) {
+      isFalsy = false;
+    }
+
+    if (isFalsy) {
       buffer.append(options.inverse());
     } else {
       buffer.append(options.fn());

--- a/handlebars/src/test/java/com/github/jknack/handlebars/issues/Issue698.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/issues/Issue698.java
@@ -1,0 +1,31 @@
+package com.github.jknack.handlebars.issues;
+
+import com.github.jknack.handlebars.v4Test;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class Issue698 extends v4Test {
+
+  @Test
+  public void shouldUseContext() throws IOException {
+    shouldCompileTo("{{#each value}}" +
+            "{{@index}}={{#if this}}true{{else}}false{{/if}}\n" +
+            "zero{{@index}}={{#if this includeZero=true}}true{{else}}false{{/if}}\n" +
+            "{{/each}}",
+        $("hash", $("value", new Object[]{null, 0, 0.0, 1, "", "0"})),
+        "0=false\n" +
+            "zero0=false\n" +
+            "1=false\n" +
+            "zero1=true\n" +
+            "2=false\n" +
+            "zero2=true\n" +
+            "3=true\n" +
+            "zero3=true\n" +
+            "4=false\n" +
+            "zero4=false\n" +
+            "5=true\n" +
+            "zero5=true\n");
+  }
+
+}


### PR DESCRIPTION
fixes #698

add flag includeZero with the same syntax/behavior as [handlebars if-helper](https://npmdoc.github.io/node-npmdoc-handlebars/build/apidoc.html#apidoc.element.handlebars.helpers.if)