### PR TITLE
Make handlebars.java work with Java 15+

### DIFF
--- a/handlebars-guava-cache/pom.xml
+++ b/handlebars-guava-cache/pom.xml
@@ -56,11 +56,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/handlebars-helpers/pom.xml
+++ b/handlebars-helpers/pom.xml
@@ -26,7 +26,7 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
@@ -59,12 +59,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/handlebars-helpers/src/test/java/com/github/jknack/handlebars/helper/JodaHelperTest.java
+++ b/handlebars-helpers/src/test/java/com/github/jknack/handlebars/helper/JodaHelperTest.java
@@ -66,7 +66,7 @@ public class JodaHelperTest extends AbstractTest {
   @Test
   public void testStyle() throws IOException {
     DateTime dateTime = new DateTime().withDate(1995, 7, 4).withTime(14, 32, 12, 0);
-    shouldCompileTo("{{jodaStyleHelper this \"SS\"}}", dateTime, "7/4/95 2:32 PM");
+    shouldCompileTo("{{jodaStyleHelper this \"SS\"}}", dateTime, "7/4/95, 2:32 PM");
   }
 
   @Test

--- a/handlebars-humanize/src/test/java/com/github/jknack/handlebars/HumanizeHelperTest.java
+++ b/handlebars-humanize/src/test/java/com/github/jknack/handlebars/HumanizeHelperTest.java
@@ -59,15 +59,15 @@ public class HumanizeHelperTest {
    */
   @Test
   public void formatCurrency_es_AR() throws IOException {
-    assertEquals("$34",
+    assertEquals("$ 34",
         handlebars.compileInline("{{formatCurrency this locale=\"es_AR\"}}")
             .apply(34));
 
-    assertEquals("$1.000",
+    assertEquals("$ 1.000",
         handlebars.compileInline("{{formatCurrency this locale=\"es_AR\"}}")
             .apply(1000));
 
-    assertEquals("$12,50",
+    assertEquals("$ 12,50",
         handlebars.compileInline("{{formatCurrency this locale=\"es_AR\"}}")
             .apply(12.5));
   }

--- a/handlebars-jackson2/pom.xml
+++ b/handlebars-jackson2/pom.xml
@@ -55,8 +55,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/Jackson2HelperTest.java
+++ b/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/Jackson2HelperTest.java
@@ -55,11 +55,11 @@ public class Jackson2HelperTest {
 
     CharSequence result = template.apply(new Blog("First Post", "..."));
 
-    assertEquals("{\n" +
-        "  \"title\" : \"First Post\",\n" +
-        "  \"body\" : \"...\",\n" +
-        "  \"comments\" : [ ]\n" +
-        "}",
+    assertEquals(String.format("{%n" +
+        "  \"title\" : \"First Post\",%n" +
+        "  \"body\" : \"...\",%n" +
+        "  \"comments\" : [ ]%n" +
+        "}"),
         result);
   }
 

--- a/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/JsonNodeValueResolverTest.java
+++ b/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/JsonNodeValueResolverTest.java
@@ -1,11 +1,10 @@
 package com.github.jknack.handlebars;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -57,17 +56,13 @@ public class JsonNodeValueResolverTest {
     String name = "binary";
     byte[] result = new byte[]{1 };
 
-    JsonNode node = createMock(JsonNode.class);
+    JsonNode node = mock(JsonNode.class);
     BinaryNode value = BinaryNode.valueOf(result);
-    expect(node.get(name)).andReturn(value);
-
-    Object[] mocks = {node };
-
-    replay(mocks);
+    when(node.get(name)).thenReturn(value);
 
     assertEquals(result, JsonNodeValueResolver.INSTANCE.resolve(node, name));
 
-    verify(mocks);
+    verify(node).get(name);
   }
 
   @Test
@@ -75,17 +70,13 @@ public class JsonNodeValueResolverTest {
     String name = "null";
     Object result = ValueResolver.UNRESOLVED;
 
-    JsonNode node = createMock(JsonNode.class);
+    JsonNode node = mock(JsonNode.class);
     NullNode value = NullNode.instance;
-    expect(node.get(name)).andReturn(value);
-
-    Object[] mocks = {node };
-
-    replay(mocks);
+    when(node.get(name)).thenReturn(value);
 
     assertEquals(result, JsonNodeValueResolver.INSTANCE.resolve(node, name));
 
-    verify(mocks);
+    verify(node).get(name);
   }
 
   @Test
@@ -93,17 +84,13 @@ public class JsonNodeValueResolverTest {
     String name = "bigInt";
     BigInteger result = BigInteger.ONE;
 
-    JsonNode node = createMock(JsonNode.class);
+    JsonNode node = mock(JsonNode.class);
     JsonNode value = BigIntegerNode.valueOf(result);
-    expect(node.get(name)).andReturn(value);
-
-    Object[] mocks = {node };
-
-    replay(mocks);
+    when(node.get(name)).thenReturn(value);
 
     assertEquals(result, JsonNodeValueResolver.INSTANCE.resolve(node, name));
 
-    verify(mocks);
+    verify(node).get(name);
   }
 
   @Test
@@ -111,17 +98,13 @@ public class JsonNodeValueResolverTest {
     String name = "decimal";
     BigDecimal result = BigDecimal.TEN;
 
-    JsonNode node = createMock(JsonNode.class);
+    JsonNode node = mock(JsonNode.class);
     JsonNode value = DecimalNode.valueOf(result);
-    expect(node.get(name)).andReturn(value);
-
-    Object[] mocks = {node };
-
-    replay(mocks);
+    when(node.get(name)).thenReturn(value);
 
     assertEquals(result, JsonNodeValueResolver.INSTANCE.resolve(node, name));
 
-    verify(mocks);
+    verify(node).get(name);
   }
 
   @Test
@@ -129,17 +112,13 @@ public class JsonNodeValueResolverTest {
     String name = "long";
     Long result = 678L;
 
-    JsonNode node = createMock(JsonNode.class);
+    JsonNode node = mock(JsonNode.class);
     JsonNode value = LongNode.valueOf(result);
-    expect(node.get(name)).andReturn(value);
-
-    Object[] mocks = {node };
-
-    replay(mocks);
+    when(node.get(name)).thenReturn(value);
 
     assertEquals(result, JsonNodeValueResolver.INSTANCE.resolve(node, name));
 
-    verify(mocks);
+    verify(node).get(name);
   }
 
   @Test
@@ -147,17 +126,13 @@ public class JsonNodeValueResolverTest {
     String name = "pojo";
     Object result = new Object();
 
-    JsonNode node = createMock(JsonNode.class);
+    JsonNode node = mock(JsonNode.class);
     JsonNode value = new POJONode(result);
-    expect(node.get(name)).andReturn(value);
-
-    Object[] mocks = {node };
-
-    replay(mocks);
+    when(node.get(name)).thenReturn(value);
 
     assertEquals(result, JsonNodeValueResolver.INSTANCE.resolve(node, name));
 
-    verify(mocks);
+    verify(node).get(name);
   }
 
   @Test

--- a/handlebars-maven-plugin-tests/pom.xml
+++ b/handlebars-maven-plugin-tests/pom.xml
@@ -10,7 +10,6 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.jknack</groupId>
   <artifactId>handlebars-maven-plugin-tests</artifactId>
-  <packaging>war</packaging>
 
   <name>Handlebars.js maven plugin tests</name>
   <description>Tests suite for handlebars-maven-plugin</description>

--- a/handlebars-maven-plugin/pom.xml
+++ b/handlebars-maven-plugin/pom.xml
@@ -86,8 +86,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/handlebars-maven-plugin/src/main/java/com/github/jknack/handlebars/maven/PrecompilePlugin.java
+++ b/handlebars-maven-plugin/src/main/java/com/github/jknack/handlebars/maven/PrecompilePlugin.java
@@ -230,7 +230,9 @@ public class PrecompilePlugin extends HandlebarsPlugin {
                 .setHash(hash)
                 .build();
 
-        writer.append("// Source: ").append(file.getPath()).append("\n");
+        //As it's just a comment (and Windows could handle forward slashes as well), we output
+        //the path as Unix style
+        writer.append("// Source: ").append(file.getPath().replaceAll("\\\\", "/")).append("\n");
         writer.append(PrecompileHelper.INSTANCE.apply(templateName, opts).toString())
             .append("\n\n");
       }

--- a/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/I18nJsPluginTest.java
+++ b/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/I18nJsPluginTest.java
@@ -1,9 +1,8 @@
 package com.github.jknack.handlebars.maven;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -96,9 +95,8 @@ public class I18nJsPluginTest {
 
   private MavenProject newProject(final String... classpath)
       throws DependencyResolutionRequiredException {
-    MavenProject project = createMock(MavenProject.class);
-    expect(project.getRuntimeClasspathElements()).andReturn(Lists.newArrayList(classpath));
-    replay(project);
+    MavenProject project = mock(MavenProject.class);
+    when(project.getRuntimeClasspathElements()).thenReturn(Lists.newArrayList(classpath));
     return project;
   }
 

--- a/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue230.java
+++ b/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue230.java
@@ -1,9 +1,8 @@
 package com.github.jknack.handlebars.maven;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
@@ -34,9 +33,8 @@ public class Issue230 {
 
   private MavenProject newProject(final String... classpath)
       throws DependencyResolutionRequiredException {
-    MavenProject project = createMock(MavenProject.class);
-    expect(project.getRuntimeClasspathElements()).andReturn(Lists.newArrayList(classpath));
-    replay(project);
+    MavenProject project = mock(MavenProject.class);
+    when(project.getRuntimeClasspathElements()).thenReturn(Lists.newArrayList(classpath));
     return project;
   }
 }

--- a/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue230.java
+++ b/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue230.java
@@ -29,7 +29,7 @@ public class Issue230 {
         "  I18n.translations['en_US'] = {\n" +
         "    \"pagination_top_of_page\": \"Inicio de la página\"\n" +
         "  };\n" +
-        "})();\n", FileUtils.fileRead("target/i230.js"));
+        "})();\n", FileUtils.fileRead("target/i230.js", "UTF-8"));
   }
 
   private MavenProject newProject(final String... classpath)

--- a/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue234.java
+++ b/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/Issue234.java
@@ -1,9 +1,8 @@
 package com.github.jknack.handlebars.maven;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
@@ -34,9 +33,8 @@ public class Issue234 {
 
   private MavenProject newProject(final String... classpath)
       throws DependencyResolutionRequiredException {
-    MavenProject project = createMock(MavenProject.class);
-    expect(project.getRuntimeClasspathElements()).andReturn(Lists.newArrayList(classpath));
-    replay(project);
+    MavenProject project = mock(MavenProject.class);
+    when(project.getRuntimeClasspathElements()).thenReturn(Lists.newArrayList(classpath));
     return project;
   }
 }

--- a/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/PrecompilePluginTest.java
+++ b/handlebars-maven-plugin/src/test/java/com/github/jknack/handlebars/maven/PrecompilePluginTest.java
@@ -1,10 +1,9 @@
 package com.github.jknack.handlebars.maven;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 
@@ -116,11 +115,9 @@ public class PrecompilePluginTest {
 
   @Test(expected = MojoFailureException.class)
   public void mustFailOnUnExpectedException() throws Exception {
-    MavenProject project = createMock(MavenProject.class);
-    Artifact artifact = createMock(Artifact.class);
-    expect(project.getRuntimeClasspathElements()).andThrow(
-        new DependencyResolutionRequiredException(artifact));
-    replay(project, artifact);
+    MavenProject project = mock(MavenProject.class);
+    when(project.getRuntimeClasspathElements()).thenThrow(
+        new DependencyResolutionRequiredException(null));
 
     PrecompilePlugin plugin = new PrecompilePlugin();
     plugin.setPrefix("src/test/resources/no templates");
@@ -201,9 +198,8 @@ public class PrecompilePluginTest {
 
   private MavenProject newProject(final String... classpath)
       throws DependencyResolutionRequiredException {
-    MavenProject project = createMock(MavenProject.class);
-    expect(project.getRuntimeClasspathElements()).andReturn(Lists.newArrayList(classpath));
-    replay(project);
+    MavenProject project = mock(MavenProject.class);
+    when(project.getRuntimeClasspathElements()).thenReturn(Lists.newArrayList(classpath));
     return project;
   }
 }

--- a/handlebars-springmvc/pom.xml
+++ b/handlebars-springmvc/pom.xml
@@ -53,23 +53,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsViewTest.java
+++ b/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/HandlebarsViewTest.java
@@ -17,13 +17,11 @@
  */
 package com.github.jknack.handlebars.springmvc;
 
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.isA;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -31,13 +29,12 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.easymock.Capture;
-import org.easymock.EasyMock;
 import org.junit.Test;
 
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.context.MapValueResolver;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit test for {@link HandlebarsView}.
@@ -50,28 +47,25 @@ public class HandlebarsViewTest {
   @Test
   @SuppressWarnings("unchecked")
   public void renderMergedTemplateModel() throws Exception {
-    Map<String, Object> model = createMock(Map.class);
+    Map<String, Object> model = mock(Map.class);
 
-    PrintWriter writer = createMock(PrintWriter.class);
+    PrintWriter writer = mock(PrintWriter.class);
 
-    Template template = createMock(Template.class);
-    Capture<Context> context = EasyMock.newCapture();
-    template.apply(capture(context), isA(PrintWriter.class));
+    Template template = mock(Template.class);
+    ArgumentCaptor<Context> captor = ArgumentCaptor.forClass(Context.class);
 
-    HttpServletRequest request = createMock(HttpServletRequest.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
 
-    HttpServletResponse response = createMock(HttpServletResponse.class);
-    expect(response.getWriter()).andReturn(writer);
-
-    replay(template, model, request, response);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(writer);
 
     HandlebarsView view = new HandlebarsView();
     view.setValueResolver(MapValueResolver.INSTANCE);
     view.setTemplate(template);
     view.renderMergedTemplateModel(model, request, response);
 
-    assertNotNull(context.getValue());
-
-    verify(template, model, request, response);
+    verify(template).apply(captor.capture(), any(PrintWriter.class));
+    assertNotNull(captor.getValue());
+    verify(response).getWriter();
   }
 }

--- a/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/MessageSourceHelperTest.java
+++ b/handlebars-springmvc/src/test/java/com/github/jknack/handlebars/springmvc/MessageSourceHelperTest.java
@@ -1,21 +1,17 @@
 package com.github.jknack.handlebars.springmvc;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.isA;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.context.MessageSource;
 
 import com.github.jknack.handlebars.Context;
@@ -24,10 +20,7 @@ import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.TagType;
 import com.github.jknack.handlebars.Template;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Options.class, MessageSourceHelper.class, Context.class })
 public class MessageSourceHelperTest {
-
   @Test(expected = NullPointerException.class)
   public void nullMessageSource() {
     new MessageSourceHelper(null);
@@ -42,29 +35,29 @@ public class MessageSourceHelperTest {
     // Options
     Object[] params = {};
     @SuppressWarnings("unchecked")
-    Map<String, Object> hash = createMock(Map.class);
-    expect(hash.get("default")).andReturn(defaultMessage);
+    Map<String, Object> hash = mock(Map.class);
+    when(hash.get("default")).thenReturn(defaultMessage);
 
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, "messageSource", TagType.VAR, ctx, fn)
         .setParams(params)
         .setHash(hash)
         .build();
 
-    MessageSource messageSource = createMock(MessageSource.class);
-    expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
-        isA(Locale.class))).andReturn(message);
-
-    replay(messageSource, hash);
+    MessageSource messageSource = mock(MessageSource.class);
+    when(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
+        any(Locale.class))).thenReturn(message);
 
     Object result =
         new MessageSourceHelper(messageSource).apply(code, options);
     assertEquals(message, result);
 
-    verify(messageSource, hash);
+    verify(hash).get("default");
+    verify(messageSource).getMessage(eq(code), eq(params), eq(defaultMessage),
+        any(Locale.class));
   }
 
   @Test
@@ -76,29 +69,29 @@ public class MessageSourceHelperTest {
     // Options
     Object[] params = {1, 2, 3 };
     @SuppressWarnings("unchecked")
-    Map<String, Object> hash = createMock(Map.class);
-    expect(hash.get("default")).andReturn(defaultMessage);
+    Map<String, Object> hash = mock(Map.class);
+    when(hash.get("default")).thenReturn(defaultMessage);
 
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, "messageSource", TagType.VAR, ctx, fn)
         .setParams(params)
         .setHash(hash)
         .build();
 
-    MessageSource messageSource = createMock(MessageSource.class);
-    expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
-        isA(Locale.class))).andReturn(message);
-
-    replay(messageSource, hash);
+    MessageSource messageSource = mock(MessageSource.class);
+    when(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
+        any(Locale.class))).thenReturn(message);
 
     Object result =
         new MessageSourceHelper(messageSource).apply(code, options);
     assertEquals(message, result);
 
-    verify(messageSource, hash);
+    verify(hash).get("default");
+    verify(messageSource).getMessage(eq(code), eq(params), eq(defaultMessage),
+        any(Locale.class));
   }
 
   @Test
@@ -110,28 +103,28 @@ public class MessageSourceHelperTest {
     // Options
     Object[] params = {1, 2, 3 };
     @SuppressWarnings("unchecked")
-    Map<String, Object> hash = createMock(Map.class);
-    expect(hash.get("default")).andReturn(defaultMessage);
+    Map<String, Object> hash = mock(Map.class);
+    when(hash.get("default")).thenReturn(defaultMessage);
 
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, "messageSource", TagType.VAR, ctx, fn)
         .setParams(params)
         .setHash(hash)
         .build();
 
-    MessageSource messageSource = createMock(MessageSource.class);
-    expect(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
-        isA(Locale.class))).andReturn(message);
-
-    replay(messageSource, hash);
+    MessageSource messageSource = mock(MessageSource.class);
+    when(messageSource.getMessage(eq(code), eq(params), eq(defaultMessage),
+        any(Locale.class))).thenReturn(message);
 
     Object result =
         new MessageSourceHelper(messageSource).apply(code, options);
     assertEquals(message, result);
 
-    verify(messageSource, hash);
+    verify(hash).get("default");
+    verify(messageSource).getMessage(eq(code), eq(params), eq(defaultMessage),
+        any(Locale.class));
   }
 }

--- a/handlebars/pom.xml
+++ b/handlebars/pom.xml
@@ -131,7 +131,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>4.2.1</version>
+        <version>5.1.2</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/handlebars/pom.xml
+++ b/handlebars/pom.xml
@@ -173,6 +173,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Nashorn JS engine -->
+    <dependency>
+      <groupId>org.openjdk.nashorn</groupId>
+      <artifactId>nashorn-core</artifactId>
+      <version>15.3</version>
+    </dependency>
+
     <!-- Logging System -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/handlebars/pom.xml
+++ b/handlebars/pom.xml
@@ -221,12 +221,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.6</version>
@@ -234,17 +228,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-easymock</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <properties>

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -1474,7 +1474,7 @@ public class Handlebars implements HelperRegistry {
     synchronized (this) {
       if (this.engine == null) {
 
-        this.engine = new ScriptEngineManager(null).getEngineByName("nashorn");
+        this.engine = new ScriptEngineManager().getEngineByName("nashorn");
 
         Throwing.run(() -> engine.eval(Files.read(this.handlebarsJsFile, charset)));
       }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
@@ -25,7 +25,7 @@ import static org.apache.commons.lang3.Validate.notNull;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Constructor;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -263,19 +263,13 @@ abstract class BaseTemplate implements Template {
           }
 
           private Object invokeDefaultMethod(final Method method, final Class<?> lookupClass,
-              final Object proxy, final Object... args)
-              throws Throwable {
-            // Jumping through these hoops is needed because calling unreflectSpecial requires that
-            // the lookup instance have private access to the special caller. None of the static
-            // factory methods for Lookup will give us an instance with the access modes we need,
-            // so we work around it by calling the private constructor via reflection.
-            Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class
-                .getDeclaredConstructor(Class.class, int.class);
-            constructor.setAccessible(true);
-            return constructor.newInstance(lookupClass, -1 /* trusted */)
-                .unreflectSpecial(method, lookupClass)
-                .bindTo(proxy)
-                .invokeWithArguments(args);
+              final Object proxy, final Object... args) throws Throwable {
+            MethodType methodType = MethodType.methodType(method.getReturnType(),
+                    method.getParameterTypes());
+            return MethodHandles.lookup()
+                    .findSpecial(lookupClass, method.getName(), methodType, lookupClass)
+                    .bindTo(proxy)
+                    .invokeWithArguments(args);
           }
 
           @Override

--- a/handlebars/src/test/java/com/github/jknack/handlebars/CollectionsLengthTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/CollectionsLengthTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class CollectionsLengthTest extends AbstractTest {
 
-  static class SizeAndLength {
+  public static class SizeAndLength {
     int size;
     int length;
 

--- a/handlebars/src/test/java/com/github/jknack/handlebars/EachKeyTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/EachKeyTest.java
@@ -48,20 +48,6 @@ public class EachKeyTest extends AbstractTest {
   }
 
   @Test
-  public void eachKeyWithString() throws IOException {
-    String result = compile("{{#each this}}{{@key}} {{/each}}").apply("String");
-
-    String expected1 = "empty bytes ";
-    String expected2 = "bytes empty ";
-    assertTrue(result.equals(expected1) || result.equals(expected2));
-  }
-
-  @Test
-  public void eachKeyWithInt() throws IOException {
-    shouldCompileTo("{{#each this}}{{@key}} {{/each}}", 7, "");
-  }
-
-  @Test
   public void eachKeyWithJavaBean() throws IOException {
     Blog blog = new Blog("Handlebars.java", "...");
     String result = compile("{{#each this}}{{@key}}: {{this}} {{/each}}").apply(blog);

--- a/handlebars/src/test/java/com/github/jknack/handlebars/HandlebarsExceptionTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/HandlebarsExceptionTest.java
@@ -1,7 +1,7 @@
 package com.github.jknack.handlebars;
 
-import static org.easymock.EasyMock.createMock;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
@@ -25,7 +25,7 @@ public class HandlebarsExceptionTest {
   @Test
   public void withErrorCause() {
     Exception cause = new NullPointerException();
-    HandlebarsError error = createMock(HandlebarsError.class);
+    HandlebarsError error = mock(HandlebarsError.class);
     HandlebarsException ex = new HandlebarsException(error, cause);
     assertEquals(cause, ex.getCause());
     assertEquals(error, ex.getError());
@@ -33,7 +33,7 @@ public class HandlebarsExceptionTest {
 
   @Test
   public void withError() {
-    HandlebarsError error = createMock(HandlebarsError.class);
+    HandlebarsError error = mock(HandlebarsError.class);
     HandlebarsException ex = new HandlebarsException(error);
     assertEquals(error, ex.getError());
   }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/Issue266.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/Issue266.java
@@ -1,9 +1,7 @@
 package com.github.jknack.handlebars;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
@@ -50,49 +48,33 @@ public class Issue266 {
 
   @Test
   public void withParserFactory() {
-    ParserFactory parserFactory = createMock(ParserFactory.class);
-
-    replay(parserFactory);
+    ParserFactory parserFactory = mock(ParserFactory.class);
 
     Handlebars handlebars = new Handlebars().with(parserFactory);
     assertNotNull(handlebars);
-
-    verify(parserFactory);
   }
 
   @Test
   public void withTemplateCache() {
-    TemplateCache cache = createMock(TemplateCache.class);
-
-    replay(cache);
+    TemplateCache cache = mock(TemplateCache.class);
 
     Handlebars handlebars = new Handlebars().with(cache);
     assertNotNull(handlebars);
-
-    verify(cache);
   }
 
   @Test
   public void withHelperRegistry() {
-    HelperRegistry registry = createMock(HelperRegistry.class);
-
-    replay(registry);
+    HelperRegistry registry = mock(HelperRegistry.class);
 
     Handlebars handlebars = new Handlebars().with(registry);
     assertNotNull(handlebars);
-
-    verify(registry);
   }
 
   @Test
   public void withEscapingStrategy() {
-    EscapingStrategy escapingStrategy = createMock(EscapingStrategy.class);
-
-    replay(escapingStrategy);
+    EscapingStrategy escapingStrategy = mock(EscapingStrategy.class);
 
     Handlebars handlebars = new Handlebars().with(escapingStrategy);
     assertNotNull(handlebars);
-
-    verify(escapingStrategy);
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/TemporalPartialTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/TemporalPartialTest.java
@@ -34,12 +34,12 @@ public class TemporalPartialTest {
       }
     });
     Template template = handlebars.compile("temporal-partials");
-    assertEquals("Items:\n" +
-        "\n" +
-        "Item: Custom\n" +
-        "...\n" +
-        "Item: 2\n" +
-        "...\n", template.apply(Arrays.asList(new Item("1"), new Item("2"))));
+    assertEquals(String.format("Items:%n" +
+        "%n" +
+        "Item: Custom%n" +
+        "...%n" +
+        "Item: 2%n" +
+        "...%n"), template.apply(Arrays.asList(new Item("1"), new Item("2"))));
   }
 
   @Test
@@ -47,17 +47,17 @@ public class TemporalPartialTest {
     Handlebars handlebars = new Handlebars();
     handlebars.setPrettyPrint(true);
     Template template = handlebars.compile("derived");
-    assertEquals("\n" +
-        "<html>\n" +
-        "<head>\n" +
-        "  <title>\n" +
-        "     Home \n" +
-        "  </title>\n" +
-        "</head>\n" +
-        "<body>\n" +
-        "  <h1> Home </h1>\n" +
-        "  HOME\n" +
-        "</body>\n" +
-        "</html>", template.apply(null));
+    assertEquals(String.format("%n" +
+        "<html>%n" +
+        "<head>%n" +
+        "  <title>%n" +
+        "     Home %n" +
+        "  </title>%n" +
+        "</head>%n" +
+        "<body>%n" +
+        "  <h1> Home </h1>%n" +
+        "  HOME%n" +
+        "</body>%n" +
+        "</html>"), template.apply(null));
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateDefaultMethodTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/TypeSafeTemplateDefaultMethodTest.java
@@ -19,7 +19,7 @@ public class TypeSafeTemplateDefaultMethodTest {
     }
   }
 
-  interface UserTemplate extends TypeSafeTemplate<User> {
+  public interface UserTemplate extends TypeSafeTemplate<User> {
     default String renderUpperCase(User user) throws IOException {
       return apply(user).toUpperCase();
     }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/cache/HighConcurrencyTemplateCacheTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/cache/HighConcurrencyTemplateCacheTest.java
@@ -1,12 +1,15 @@
 package com.github.jknack.handlebars.cache;
 
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
@@ -15,13 +18,11 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import com.github.jknack.handlebars.HandlebarsException;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
 import org.junit.Test;
 
-import com.github.jknack.handlebars.HandlebarsException;
 import com.github.jknack.handlebars.Parser;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.io.ForwardingTemplateSource;
@@ -29,7 +30,6 @@ import com.github.jknack.handlebars.io.TemplateSource;
 import com.github.jknack.handlebars.io.URLTemplateSource;
 
 public class HighConcurrencyTemplateCacheTest {
-
   @Test
   public void defaultConstructor() throws IOException {
     new HighConcurrencyTemplateCache();
@@ -47,12 +47,10 @@ public class HighConcurrencyTemplateCacheTest {
     TemplateSource source = new URLTemplateSource("/template.hbs", getClass().getResource(
         "/template.hbs"));
 
-    Template template = createMock(Template.class);
+    Template template = mock(Template.class);
 
-    Parser parser = createMock(Parser.class);
-    expect(parser.parse(source)).andReturn(template);
-
-    replay(parser, template);
+    Parser parser = mock(Parser.class);
+    when(parser.parse(source)).thenReturn(template);
 
     // 1st call, parse must be call it
     assertEquals(template, new HighConcurrencyTemplateCache(cache).get(source, parser));
@@ -60,86 +58,86 @@ public class HighConcurrencyTemplateCacheTest {
     // 2nd call, should return from cache
     assertEquals(template, new HighConcurrencyTemplateCache(cache).get(source, parser));
 
-    verify(parser, template);
+    verify(parser).parse(source);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void interruptThreadOnInterruptedException() throws Exception {
-    assertEquals(false, Thread.currentThread().isInterrupted());
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    assertFalse(Thread.currentThread().isInterrupted());
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentHashMap.class);
 
     TemplateSource source = new URLTemplateSource("/template.hbs", getClass().getResource(
         "/template.hbs"));
 
-    Future<Pair<TemplateSource, Template>> future = createMock(Future.class);
+    Future<Pair<TemplateSource, Template>> future = mock(Future.class);
     // 1st try interrupt thread
-    expect(cache.get(source)).andReturn(future);
-    expect(future.get()).andThrow(new InterruptedException());
+    when(cache.get(source)).thenReturn(future);
+    Pair<TemplateSource, Template> pair = mock(Pair.class);
+    when(future.get()).thenThrow(new InterruptedException())
+            .thenReturn(pair);
 
     // 2nd success
-    Template template = createMock(Template.class);
-    Pair<TemplateSource, Template> pair = createMock(Pair.class);
-    expect(pair.getValue()).andReturn(template);
-    expect(cache.get(source)).andReturn(future);
-    expect(future.get()).andReturn(pair);
+    Template template = mock(Template.class);
+    when(pair.getValue()).thenReturn(template);
 
-    Parser parser = createMock(Parser.class);
-
-    replay(parser, template, cache, future, pair);
+    Parser parser = mock(Parser.class);
 
     // 1st call, parse must be call it
     assertEquals(template, new HighConcurrencyTemplateCache(cache).get(source, parser));
-    assertEquals(true, Thread.currentThread().isInterrupted());
+    assertTrue(Thread.currentThread().isInterrupted());
 
-    verify(parser, template, cache, future, pair);
+    verify(cache, times(2)).get(source);
+    verify(future, times(2)).get();
+    verify(pair).getValue();
   }
 
   @Test(expected = Error.class)
   @SuppressWarnings("unchecked")
   public void errorShouldBeReThrow() throws Exception {
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentHashMap.class);
 
     TemplateSource source = new URLTemplateSource("/template.hbs", getClass().getResource(
         "/template.hbs"));
 
-    Future<Pair<TemplateSource, Template>> future = createMock(Future.class);
+    Future<Pair<TemplateSource, Template>> future = mock(Future.class);
     // 1st try interrupt thread
-    expect(cache.get(source)).andReturn(future);
-    expect(future.get()).andThrow(new Error());
+    when(cache.get(source)).thenReturn(future);
+    when(future.get()).thenThrow(new Error());
 
     // 2nd success
-    Template template = createMock(Template.class);
-    Pair<TemplateSource, Template> pair = createMock(Pair.class);
-    expect(pair.getLeft()).andReturn(source);
-    expect(pair.getValue()).andReturn(template);
-    expect(cache.get(source)).andReturn(future);
-    expect(future.get()).andReturn(pair).times(2);
+    Template template = mock(Template.class);
+    Pair<TemplateSource, Template> pair = mock(Pair.class);
+    when(pair.getLeft()).thenReturn(source);
+    when(pair.getValue()).thenReturn(template);
+    when(future.get()).thenReturn(pair);
 
-    Parser parser = createMock(Parser.class);
-
-    replay(parser, template, cache, future, pair);
+    Parser parser = mock(Parser.class);
 
     // 1st call, parse must be call it
     assertEquals(template, new HighConcurrencyTemplateCache(cache).get(source, parser));
 
-    verify(parser, template, cache, future, pair);
+    verify(cache, times(2)).get(source);
+    verify(future, times(3)).get();
+    verify(pair).getLeft();
+    verify(pair).getValue();
   }
 
   @Test
   public void getAndReload() throws IOException, InterruptedException {
     ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = new ConcurrentHashMap<>();
 
-    TemplateSource source = source("/template.hbs");
+    TemplateSource source = new URLTemplateSource("/template.hbs", getClass().getResource(
+        "/template.hbs"));
 
-    Template template = createMock(Template.class);
+    Template template = mock(Template.class);
 
-    Template reloadTemplate = createMock(Template.class);
+    Template reloadTemplate = mock(Template.class);
 
-    Parser parser = createMock(Parser.class);
-    expect(parser.parse(source)).andReturn(template);
+    Parser parser = mock(Parser.class);
+    when(parser.parse(same(source))).thenReturn(template);
 
     TemplateSource reloadSource = new ForwardingTemplateSource(source) {
       @Override
@@ -147,9 +145,7 @@ public class HighConcurrencyTemplateCacheTest {
         return System.currentTimeMillis() * 7;
       }
     };
-    expect(parser.parse(reloadSource)).andReturn(reloadTemplate);
-
-    replay(parser, template, reloadTemplate);
+    when(parser.parse(same(reloadSource))).thenReturn(reloadTemplate);
 
     // 1st call, parse must be call it
     assertEquals(template,
@@ -163,166 +159,138 @@ public class HighConcurrencyTemplateCacheTest {
     assertEquals(reloadTemplate,
         new HighConcurrencyTemplateCache(cache).setReload(true).get(reloadSource, parser));
 
-    verify(parser, template, reloadTemplate);
+    verify(parser).parse(same(source));
+    verify(parser).parse(same(reloadSource));
   }
 
   @Test
   public void evict() throws IOException {
-    TemplateSource source = createMock(TemplateSource.class);
+    TemplateSource source = mock(TemplateSource.class);
 
     @SuppressWarnings("unchecked")
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentMap.class);
-    expect(cache.remove(source)).andReturn(null);
-
-    replay(cache, source);
+    when(cache.remove(source)).thenReturn(null);
 
     new HighConcurrencyTemplateCache(cache).evict(source);
 
-    verify(cache, source);
+    verify(cache).remove(source);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void cancellationException() throws IOException, InterruptedException, ExecutionException {
-    TemplateSource source = createMock(TemplateSource.class);
+    TemplateSource source = mock(TemplateSource.class);
 
-    Template template = createMock(Template.class);
+    Template template = mock(Template.class);
 
-    Future<Pair<TemplateSource, Template>> future = createMock(Future.class);
-    expect(future.get()).andThrow(new CancellationException());
-    expect(future.get()).andReturn(ImmutablePair.<TemplateSource, Template> of(source, template));
+    Future<Pair<TemplateSource, Template>> future = mock(Future.class);
+    when(future.get()).thenThrow(new CancellationException())
+        .thenReturn(ImmutablePair.of(source, template));
 
-    Capture<TemplateSource> keyGet = EasyMock.newCapture();
-    Capture<TemplateSource> keyRemove = EasyMock.newCapture();
-
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentMap.class);
-    expect(cache.get(capture(keyGet))).andReturn(future).times(2);
-    expect(cache.remove(capture(keyRemove), eq(future))).andReturn(true);
+    when(cache.get(any(TemplateSource.class))).thenReturn(future);
+    when(cache.remove(any(TemplateSource.class), eq(future))).thenReturn(true);
 
-    Parser parser = createMock(Parser.class);
-
-    Object[] mocks = {cache, source, future, template };
-
-    replay(mocks);
+    Parser parser = mock(Parser.class);
 
     Template result = new HighConcurrencyTemplateCache(cache).get(source, parser);
     assertEquals(template, result);
 
-    verify(mocks);
+    verify(future, times(2)).get();
+    verify(cache, times(2)).get(any(TemplateSource.class));
+    verify(cache).remove(any(TemplateSource.class), eq(future));
   }
 
   @Test(expected = IllegalArgumentException.class)
   @SuppressWarnings("unchecked")
   public void runtimeException() throws IOException, InterruptedException, ExecutionException {
-    TemplateSource source = createMock(TemplateSource.class);
-    expect(source.lastModified()).andReturn(615L).times(3);
+    TemplateSource source = mock(TemplateSource.class);
+    when(source.lastModified()).thenReturn(615L);
 
-    Template template = createMock(Template.class);
+    Template template = mock(Template.class);
 
-    Future<Pair<TemplateSource, Template>> future = createMock(Future.class);
-    expect(future.get()).andThrow(new ExecutionException(new IllegalArgumentException()));
+    Future<Pair<TemplateSource, Template>> future = mock(Future.class);
+    when(future.get()).thenThrow(new ExecutionException(new IllegalArgumentException()));
 
-    Capture<TemplateSource> keyGet = EasyMock.newCapture();
-    Capture<TemplateSource> keyRemove = EasyMock.newCapture();
-
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentMap.class);
+    when(cache.get(any(TemplateSource.class))).thenReturn(future);
+    when(cache.remove(any(TemplateSource.class), eq(future))).thenReturn(true);
 
-    expect(cache.get(capture(keyGet))).andReturn(future);
-    expect(cache.remove(capture(keyRemove), eq(future))).andReturn(true);
-
-    Parser parser = createMock(Parser.class);
-
-    Object[] mocks = {cache, source, future, template };
-
-    replay(mocks);
+    Parser parser = mock(Parser.class);
 
     Template result = new HighConcurrencyTemplateCache(cache).get(source, parser);
     assertEquals(template, result);
 
-    verify(mocks);
+    verify(source, times(3)).lastModified();
+    verify(future).get();
+    verify(cache).get(any(TemplateSource.class));
+    verify(cache).remove(any(TemplateSource.class), eq(future));
   }
 
   @Test(expected = Error.class)
   @SuppressWarnings("unchecked")
   public void errorException() throws IOException, InterruptedException, ExecutionException {
-    TemplateSource source = createMock(TemplateSource.class);
-    expect(source.lastModified()).andReturn(615L).times(3);
+    TemplateSource source = mock(TemplateSource.class);
+    when(source.lastModified()).thenReturn(615L);
 
-    Template template = createMock(Template.class);
+    Template template = mock(Template.class);
 
-    Future<Pair<TemplateSource, Template>> future = createMock(Future.class);
-    expect(future.get()).andThrow(new ExecutionException(new Error()));
+    Future<Pair<TemplateSource, Template>> future = mock(Future.class);
+    when(future.get()).thenThrow(new ExecutionException(new Error()));
 
-    Capture<TemplateSource> keyGet = EasyMock.newCapture();
-
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentMap.class);
-    expect(cache.get(capture(keyGet))).andReturn(future);
+    when(cache.get(any(TemplateSource.class))).thenReturn(future);
 
-    Parser parser = createMock(Parser.class);
-
-    Object[] mocks = {cache, source, future, template };
-
-    replay(mocks);
+    Parser parser = mock(Parser.class);
 
     Template result = new HighConcurrencyTemplateCache(cache).get(source, parser);
     assertEquals(template, result);
 
-    verify(mocks);
+    verify(source, times(3)).lastModified();
+    verify(future).get();
+    verify(cache).get(any(TemplateSource.class));
   }
 
   @Test(expected = HandlebarsException.class)
   @SuppressWarnings("unchecked")
   public void hbsException() throws IOException, InterruptedException, ExecutionException {
-    TemplateSource source = createMock(TemplateSource.class);
-    expect(source.filename()).andReturn("filename");
-    expect(source.lastModified()).andReturn(615L);
+    TemplateSource source = mock(TemplateSource.class);
+    when(source.filename()).thenReturn("filename");
+    when(source.lastModified()).thenReturn(615L);
 
-    Template template = createMock(Template.class);
+    Template template = mock(Template.class);
 
-    Future<Pair<TemplateSource, Template>> future = createMock(Future.class);
-    expect(future.get()).andThrow(new ExecutionException(new Exception()));
+    Future<Pair<TemplateSource, Template>> future = mock(Future.class);
+    when(future.get()).thenThrow(new ExecutionException(new Exception()));
 
-    Capture<TemplateSource> keyGet = EasyMock.newCapture();
-    Capture<TemplateSource> keyRemove = EasyMock.newCapture();
-
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentMap.class);
-    expect(cache.get(capture(keyGet))).andReturn(future);
-    expect(cache.remove(capture(keyRemove), eq(future))).andReturn(true);
+    when(cache.get(any(TemplateSource.class))).thenReturn(future);
+    when(cache.remove(any(TemplateSource.class), eq(future))).thenReturn(true);
 
-    Parser parser = createMock(Parser.class);
-
-    Object[] mocks = {cache, source, future, template };
-
-    replay(mocks);
+    Parser parser = mock(Parser.class);
 
     Template result = new HighConcurrencyTemplateCache(cache).get(source, parser);
     assertEquals(template, result);
 
-    verify(mocks);
+    verify(source).filename();
+    verify(source).lastModified();
+    verify(future).get();
+    verify(cache).get(any(TemplateSource.class));
+    verify(cache).remove(any(TemplateSource.class), eq(future));
   }
 
   @Test
   public void clear() throws IOException {
     @SuppressWarnings("unchecked")
-    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = createMock(
+    ConcurrentMap<TemplateSource, Future<Pair<TemplateSource, Template>>> cache = mock(
         ConcurrentMap.class);
     cache.clear();
 
-    replay(cache);
-
     new HighConcurrencyTemplateCache(cache).clear();
-
-    verify(cache);
-  }
-
-  private TemplateSource source(final String filename) throws IOException {
-    TemplateSource source = new URLTemplateSource(filename, getClass().getResource(
-        filename));
-    return source;
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/cache/NullTemplateCacheTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/cache/NullTemplateCacheTest.java
@@ -1,10 +1,9 @@
 package com.github.jknack.handlebars.cache;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
@@ -23,29 +22,23 @@ public class NullTemplateCacheTest {
 
   @Test
   public void evict() {
-    TemplateSource source = createMock(TemplateSource.class);
-
-    replay(source);
+    TemplateSource source = mock(TemplateSource.class);
 
     NullTemplateCache.INSTANCE.evict(source);
-
-    verify(source);
   }
 
   @Test
   public void get() throws IOException {
-    TemplateSource source = createMock(TemplateSource.class);
+    TemplateSource source = mock(TemplateSource.class);
 
-    Template template = createMock(Template.class);
+    Template template = mock(Template.class);
 
-    Parser parser = createMock(Parser.class);
-    expect(parser.parse(source)).andReturn(template);
-
-    replay(source, parser, template);
+    Parser parser = mock(Parser.class);
+    when(parser.parse(source)).thenReturn(template);
 
     Template result = NullTemplateCache.INSTANCE.get(source, parser);
     assertEquals(template, result);
 
-    verify(source, parser, template);
+    verify(parser).parse(source);
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/helper/StringHelpersTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/helper/StringHelpersTest.java
@@ -17,12 +17,15 @@ import static com.github.jknack.handlebars.helper.StringHelpers.substring;
 import static com.github.jknack.handlebars.helper.StringHelpers.upper;
 import static com.github.jknack.handlebars.helper.StringHelpers.wordWrap;
 import static com.github.jknack.handlebars.helper.StringHelpers.yesno;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.*;
@@ -47,86 +50,80 @@ public class StringHelpersTest extends AbstractTest {
 
   @Test
   public void capFirst() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("capitalizeFirst", capitalizeFirst.name());
     assertEquals("Handlebars.java",
         capitalizeFirst.apply("handlebars.java", options));
 
-    verify(options);
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void center() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("size")).andReturn(19);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-    expect(options.hash("pad", " ")).andReturn(null);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("size")).thenReturn(19);
+    when(options.isFalsy(any())).thenReturn(false);
+    when(options.hash("pad", " ")).thenReturn(null);
 
     assertEquals("center", center.name());
     assertEquals("  Handlebars.java  ",
         center.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).hash("size");
+    verify(options).isFalsy(any());
+    verify(options).hash("pad", " ");
   }
 
   @Test
   public void centerWithPad() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("size")).andReturn(19);
-    expect(options.hash("pad", " ")).andReturn("*");
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("size")).thenReturn(19);
+    when(options.hash("pad", " ")).thenReturn("*");
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("center", center.name());
     assertEquals("**Handlebars.java**",
         center.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).hash("size");
+    verify(options).hash("pad", " ");
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void cut() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.param(0, " ")).andReturn(" ");
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.param(0, " ")).thenReturn(" ");
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("cut", cut.name());
     assertEquals("handlebars.java",
         cut.apply("handle bars .  java", options));
 
-    verify(options);
+    verify(options).param(0, " ");
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void cutNoWhitespace() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.param(0, " ")).andReturn("*");
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.param(0, " ")).thenReturn("*");
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("cut", cut.name());
     assertEquals("handlebars.java",
         cut.apply("handle*bars*.**java", options));
 
-    verify(options);
+    verify(options).param(0, " ");
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void defaultStr() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.param(0, "")).andReturn("handlebars.java").anyTimes();
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.param(0, "")).thenReturn("handlebars.java");
 
     assertEquals("defaultIfEmpty", defaultIfEmpty.name());
     assertEquals("handlebars.java",
@@ -139,7 +136,7 @@ public class StringHelpersTest extends AbstractTest {
     assertEquals("something",
         defaultIfEmpty.apply("something", options));
 
-    verify(options);
+    verify(options, times(3)).param(anyInt(), anyString());
   }
 
   @Test
@@ -180,73 +177,73 @@ public class StringHelpersTest extends AbstractTest {
 
   @Test
   public void ljust() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("size")).andReturn(20);
-    expect(options.hash("pad", " ")).andReturn(null);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("size")).thenReturn(20);
+    when(options.hash("pad", " ")).thenReturn(null);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("ljust", ljust.name());
     assertEquals("Handlebars.java     ",
         ljust.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).hash("size");
+    verify(options).hash("pad", " ");
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void ljustWithPad() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("size")).andReturn(17);
-    expect(options.hash("pad", " ")).andReturn("+");
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("size")).thenReturn(17);
+    when(options.hash("pad", " ")).thenReturn("+");
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("ljust", ljust.name());
     assertEquals("Handlebars.java++",
         ljust.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).hash("size");
+    verify(options).hash("pad", " ");
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void rjust() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("size")).andReturn(20);
-    expect(options.hash("pad", " ")).andReturn(null);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("size")).thenReturn(20);
+    when(options.hash("pad", " ")).thenReturn(null);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("rjust", rjust.name());
     assertEquals("     Handlebars.java",
         rjust.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).hash("size");
+    verify(options).hash("pad", " ");
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void rjustWithPad() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("size")).andReturn(17);
-    expect(options.hash("pad", " ")).andReturn("+");
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("size")).thenReturn(17);
+    when(options.hash("pad", " ")).thenReturn("+");
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("rjust", rjust.name());
     assertEquals("++Handlebars.java",
         rjust.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).hash("size");
+    verify(options).hash("pad", " ");
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void substringWithStart() throws IOException {
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, substring.name(), TagType.VAR, ctx, fn)
         .setParams(new Object[]{11 })
@@ -259,9 +256,9 @@ public class StringHelpersTest extends AbstractTest {
 
   @Test
   public void substringWithStartAndEnd() throws IOException {
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, substring.name(), TagType.VAR, ctx, fn)
         .setParams(new Object[]{0, 10 })
@@ -274,51 +271,45 @@ public class StringHelpersTest extends AbstractTest {
 
   @Test
   public void lower() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("lower", lower.name());
     assertEquals("handlebars.java",
         lower.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void upper() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("upper", upper.name());
     assertEquals("HANDLEBARS.JAVA",
         upper.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void slugify() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("slugify", slugify.name());
     assertEquals("joel-is-a-slug",
         slugify.apply("  Joel is a slug  ", options));
 
-    verify(options);
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void replace() throws IOException {
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, replace.name(), TagType.VAR, ctx, fn)
         .setParams(new Object[]{"...", "rocks" })
@@ -331,9 +322,9 @@ public class StringHelpersTest extends AbstractTest {
 
   @Test
   public void stringFormat() throws IOException {
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, stringFormat.name(), TagType.VAR, ctx, fn)
         .setParams(new Object[]{"handlebars.java" })
@@ -347,9 +338,9 @@ public class StringHelpersTest extends AbstractTest {
 
   @Test
   public void stringDecimalFormat() throws IOException {
-    Handlebars hbs = createMock(Handlebars.class);
-    Context ctx = createMock(Context.class);
-    Template fn = createMock(Template.class);
+    Handlebars hbs = mock(Handlebars.class);
+    Context ctx = mock(Context.class);
+    Template fn = mock(Template.class);
 
     Options options = new Options.Builder(hbs, stringFormat.name(), TagType.VAR, ctx, fn)
         .setParams(new Object[]{10.0 / 3.0 })
@@ -363,25 +354,21 @@ public class StringHelpersTest extends AbstractTest {
 
   @Test
   public void stripTags() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("stripTags", stripTags.name());
     assertEquals("Joel is a slug",
         stripTags.apply("<b>Joel</b> <button>is</button> a <span>slug</span>",
             options));
 
-    verify(options);
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void stripTagsMultiLine() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("stripTags", stripTags.name());
     assertEquals("Joel\nis a slug",
@@ -389,17 +376,15 @@ public class StringHelpersTest extends AbstractTest {
             "<b>Joel</b>\n<button>is<\n/button> a <span>slug</span>",
             options));
 
-    verify(options);
+    verify(options).isFalsy(any());
   }
 
   @Test
   public void capitalize() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("fully", false)).andReturn(false);
-    expect(options.hash("fully", false)).andReturn(true);
-    expect(options.isFalsy(anyObject())).andReturn(false).times(2);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("fully", false)).thenReturn(false)
+            .thenReturn(true);
+    when(options.isFalsy(any())).thenReturn(false);
 
     assertEquals("capitalize", capitalize.name());
 
@@ -409,32 +394,30 @@ public class StringHelpersTest extends AbstractTest {
     assertEquals("Handlebars Java",
         capitalize.apply("HAndleBars JAVA", options));
 
-    verify(options);
+    verify(options, times(2)).hash("fully", false);
+    verify(options, times(2)).isFalsy(any());
   }
 
   @Test
   public void abbreviate() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-    expect(options.param(0, null)).andReturn(13);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
+    when(options.param(0, null)).thenReturn(13);
 
     assertEquals("abbreviate", abbreviate.name());
 
     assertEquals("Handlebars...",
         abbreviate.apply("Handlebars.java", options));
 
-    verify(options);
+    verify(options).isFalsy(any());
+    verify(options).param(0, null);
   }
 
   @Test
   public void wordWrap() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(false);
-    expect(options.param(0, null)).andReturn(5);
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(false);
+    when(options.param(0, null)).thenReturn(5);
 
     assertEquals("wordWrap", wordWrap.name());
 
@@ -442,17 +425,16 @@ public class StringHelpersTest extends AbstractTest {
         + System.lineSeparator() + "slug",
         wordWrap.apply("Joel is a slug", options));
 
-    verify(options);
+    verify(options).isFalsy(any());
+    verify(options).param(0, null);
   }
 
   @Test
   public void yesno() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("yes", "yes")).andReturn("yes");
-    expect(options.hash("no", "no")).andReturn("no");
-    expect(options.hash("maybe", "maybe")).andReturn("maybe");
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("yes", "yes")).thenReturn("yes");
+    when(options.hash("no", "no")).thenReturn("no");
+    when(options.hash("maybe", "maybe")).thenReturn("maybe");
 
     assertEquals("yesno", yesno.name());
 
@@ -460,17 +442,17 @@ public class StringHelpersTest extends AbstractTest {
     assertEquals("no", yesno.apply(false, options));
     assertEquals("maybe", yesno.apply(null, options));
 
-    verify(options);
+    verify(options).hash("yes", "yes");
+    verify(options).hash("no", "no");
+    verify(options).hash("maybe", "maybe");
   }
 
   @Test
   public void yesnoCustom() throws IOException {
-    Options options = createMock(Options.class);
-    expect(options.hash("yes", "yes")).andReturn("yea");
-    expect(options.hash("no", "no")).andReturn("nop");
-    expect(options.hash("maybe", "maybe")).andReturn("whatever");
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.hash("yes", "yes")).thenReturn("yea");
+    when(options.hash("no", "no")).thenReturn("nop");
+    when(options.hash("maybe", "maybe")).thenReturn("whatever");
 
     assertEquals("yesno", yesno.name());
 
@@ -478,71 +460,67 @@ public class StringHelpersTest extends AbstractTest {
     assertEquals("nop", yesno.apply(false, options));
     assertEquals("whatever", yesno.apply(null, options));
 
-    verify(options);
+    verify(options).hash("yes", "yes");
+    verify(options).hash("no", "no");
+    verify(options).hash("maybe", "maybe");
   }
 
   @Test
   public void nullContext() throws IOException {
-    Set<Helper<Object>> helpers = new LinkedHashSet<Helper<Object>>(Arrays.asList(StringHelpers
-        .values()));
+    Set<Helper<Object>> helpers = new LinkedHashSet<>(Arrays.asList(StringHelpers.values()));
     helpers.remove(StringHelpers.join);
     helpers.remove(StringHelpers.yesno);
     helpers.remove(StringHelpers.defaultIfEmpty);
 
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(true).times(helpers.size() - 1);
-    expect(options.param(0, null)).andReturn(null).times(helpers.size());
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(true);
+    when(options.param(0, null)).thenReturn(null);
 
     for (Helper<Object> helper : helpers) {
-      assertEquals(null, helper.apply($, options));
+      assertNull(helper.apply($, options));
     }
 
-    verify(options);
+    verify(options, times(helpers.size() - 1)).isFalsy(any());
+    verify(options, times(helpers.size())).param(0, null);
   }
 
   @Test
   public void nullContextWithDefault() throws IOException {
-    Set<Helper<Object>> helpers = new LinkedHashSet<Helper<Object>>(Arrays.asList(StringHelpers
-        .values()));
+    Set<Helper<Object>> helpers = new LinkedHashSet<>(Arrays.asList(StringHelpers.values()));
     helpers.remove(StringHelpers.join);
     helpers.remove(StringHelpers.yesno);
     helpers.remove(StringHelpers.defaultIfEmpty);
 
     String nothing = "nothing";
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(true).times(helpers.size() - 1);
-    expect(options.param(0, null)).andReturn(nothing).times(helpers.size());
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(true);
+    when(options.param(0, null)).thenReturn(nothing);
 
     for (Helper<Object> helper : helpers) {
       assertEquals(nothing, helper.apply($, options));
     }
 
-    verify(options);
+    verify(options, times(helpers.size() - 1)).isFalsy(any());
+    verify(options, times(helpers.size())).param(0, null);
   }
 
   @Test
   public void nullContextWithNumber() throws IOException {
-    Set<Helper<Object>> helpers = new LinkedHashSet<Helper<Object>>(Arrays.asList(StringHelpers
-        .values()));
+    Set<Helper<Object>> helpers = new LinkedHashSet<>(Arrays.asList(StringHelpers.values()));
     helpers.remove(StringHelpers.join);
     helpers.remove(StringHelpers.yesno);
     helpers.remove(StringHelpers.defaultIfEmpty);
 
     Object number = 32;
-    Options options = createMock(Options.class);
-    expect(options.isFalsy(anyObject())).andReturn(true).times(helpers.size() - 1);
-    expect(options.param(0, null)).andReturn(number).times(helpers.size());
-
-    replay(options);
+    Options options = mock(Options.class);
+    when(options.isFalsy(any())).thenReturn(true);
+    when(options.param(0, null)).thenReturn(number);
 
     for (Helper<Object> helper : helpers) {
       assertEquals(number.toString(), helper.apply($, options));
     }
 
-    verify(options);
+    verify(options, times(helpers.size() - 1)).isFalsy(any());
+    verify(options, times(helpers.size())).param(0, null);
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i275/Issue275.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i275/Issue275.java
@@ -41,12 +41,12 @@ public class Issue275 {
       }
     });
     Template template = handlebars.compile("temporal-partials");
-    assertEquals("Items:\n" +
-        "\n" +
-        "Item: Custom\n" +
-        "...\n" +
-        "Item: 2\n" +
-        "...\n", template.apply(Arrays.asList(new Item("1"), new Item("2"))));
+    assertEquals(String.format("Items:%n" +
+        "%n" +
+        "Item: Custom%n" +
+        "...%n" +
+        "Item: 2%n" +
+        "...%n"), template.apply(Arrays.asList(new Item("1"), new Item("2"))));
   }
 
   @Test
@@ -63,11 +63,12 @@ public class Issue275 {
       }
     });
     Template template = handlebars.compile("temporal-partials");
-    assertEquals("Items:\n" +
-        "\n" +
-        "Item: Custom\n" +
-        "...\n" +
-        "Item: Custom\n" +
-        "...\n", template.apply(Arrays.asList(new Item("1"), new Item("2"))));
+
+    assertEquals(String.format("Items:%n" +
+        "%n" +
+        "Item: Custom%n" +
+        "...%n" +
+        "Item: Custom%n" +
+        "...%n"), template.apply(Arrays.asList(new Item("1"), new Item("2"))));
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/io/ForwardingTemplateSourceTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/io/ForwardingTemplateSourceTest.java
@@ -1,10 +1,9 @@
 package com.github.jknack.handlebars.io;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -15,41 +14,35 @@ public class ForwardingTemplateSourceTest {
 
   @Test
   public void content() throws IOException {
-    TemplateSource source = createMock(TemplateSource.class);
-    expect(source.content(StandardCharsets.UTF_8)).andReturn("abc");
-
-    replay(source);
+    TemplateSource source = mock(TemplateSource.class);
+    when(source.content(StandardCharsets.UTF_8)).thenReturn("abc");
 
     assertEquals("abc", new ForwardingTemplateSource(source).content(StandardCharsets.UTF_8));
 
-    verify(source);
+    verify(source).content(StandardCharsets.UTF_8);
   }
 
   @Test
   public void filename() throws IOException {
     String filename = "filename";
 
-    TemplateSource source = createMock(TemplateSource.class);
-    expect(source.filename()).andReturn(filename);
-
-    replay(source);
+    TemplateSource source = mock(TemplateSource.class);
+    when(source.filename()).thenReturn(filename);
 
     assertEquals("filename", new ForwardingTemplateSource(source).filename());
 
-    verify(source);
+    verify(source).filename();
   }
 
   @Test
   public void lastModified() throws IOException {
     long lastModified = 716L;
 
-    TemplateSource source = createMock(TemplateSource.class);
-    expect(source.lastModified()).andReturn(lastModified);
-
-    replay(source);
+    TemplateSource source = mock(TemplateSource.class);
+    when(source.lastModified()).thenReturn(lastModified);
 
     assertEquals(lastModified, new ForwardingTemplateSource(source).lastModified());
 
-    verify(source);
+    verify(source).lastModified();
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/io/ServletContextTemplateLoaderTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/io/ServletContextTemplateLoaderTest.java
@@ -1,146 +1,119 @@
 package com.github.jknack.handlebars.io;
 
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
 
 import javax.servlet.ServletContext;
 
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Test;
 
 public class ServletContextTemplateLoaderTest {
-
   @Test
   public void sourceAt() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext).sourceAt("template");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   @Test
   public void subFolder() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext, "/", ".yml")
         .sourceAt("mustache/specs/comments");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   @Test
   public void subFolderwithDashAtBeginning() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext, "/", ".yml")
         .sourceAt("/mustache/specs/comments");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   @Test(expected = FileNotFoundException.class)
   public void fileNotFound() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext).sourceAt("notExist");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   @Test
   public void setBasePath() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources/mustache/specs");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext, "/", ".yml")
         .sourceAt("comments");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   @Test
   public void setBasePathWithDash() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources/mustache/specs/");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext, "/", ".yml")
         .sourceAt("comments");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   @Test
   public void nullSuffix() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources/");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext, "/", null)
         .sourceAt("noextension");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   @Test
   public void emotySuffix() throws IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
+    ServletContext servletContext = mock(ServletContext.class);
     expectGetResource(servletContext, "src/test/resources/");
-
-    replay(servletContext);
 
     TemplateSource source = new ServletContextTemplateLoader(servletContext, "/", "")
         .sourceAt("noextension");
     assertNotNull(source);
 
-    verify(servletContext);
+    verify(servletContext).getResource(anyString());
   }
 
   private void expectGetResource(final ServletContext servletContext, final String prefix)
       throws IOException {
-    final Capture<String> path = EasyMock.newCapture();
-    expect(servletContext.getResource(capture(path))).andAnswer(
-        new IAnswer<URL>() {
-          @Override
-          public URL answer() throws Throwable {
-            File file = new File(prefix, path.getValue());
-            return file.exists() ? file.toURI().toURL() : null;
-          }
-        });
+    when(servletContext.getResource(anyString())).thenAnswer(invocation -> {
+        File file = new File(prefix, invocation.getArgument(0));
+        return file.exists() ? file.toURI().toURL() : null;
+    });
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs507.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs507.java
@@ -61,19 +61,19 @@ public class Hbs507 extends v4Test {
         $("aggregateId", "ID:y0", "aggregateType", "brett", "businessKey", "favre"));
 
     Template template = handlebars.compile("a");
-    assertEquals("This is a test for: \"ID:x0\"\n" +
-        "\n" +
-        "\"metadata.aggregateId\" : \"ID:x0\" \n" +
-        "\"metadata.businessKey\" : \"favre\"\n" +
-        "\n" +
-        "End test", template.apply(h1));
+    assertEquals(String.format("This is a test for: \"ID:x0\"%n" +
+        "%n" +
+        "\"metadata.aggregateId\" : \"ID:x0\" %n" +
+        "\"metadata.businessKey\" : \"favre\"%n" +
+        "%n" +
+        "End test"), template.apply(h1));
 
-    assertEquals("This is a test for: \"ID:y0\"\n" +
-        "\n" +
-        "\"metadata.aggregateId\" : \"ID:y0\" \n" +
-        "\"metadata.businessKey\" : \"favre\"\n" +
-        "\n" +
-        "End test", template.apply(h2));
+    assertEquals(String.format("This is a test for: \"ID:y0\"%n" +
+        "%n" +
+        "\"metadata.aggregateId\" : \"ID:y0\" %n" +
+        "\"metadata.businessKey\" : \"favre\"%n" +
+        "%n" +
+        "End test"), template.apply(h2));
   }
 
 }

--- a/handlebars/src/test/java/mustache/specs/SpecRunner.java
+++ b/handlebars/src/test/java/mustache/specs/SpecRunner.java
@@ -17,18 +17,17 @@
  */
 package mustache.specs;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.junit.runner.Description;
 import org.junit.runners.Parameterized;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
 
 public class SpecRunner extends Parameterized {
-
   private List<String> labels;
-
   private Description labelledDescription;
 
   public SpecRunner(final Class<?> cl) throws Throwable {
@@ -37,120 +36,28 @@ public class SpecRunner extends Parameterized {
     generateLabelledDescription();
   }
 
-  private void initialiseLabels() throws Exception {
-    Collection<Object[]> parameterArrays = getParameterArrays();
+  private void initialiseLabels() throws Throwable {
+    Collection<Object[]> parameterArrays = getParameterArrays4_4();
     labels = new ArrayList<String>();
     for (Object[] parameterArray : parameterArrays) {
       Spec spec = (Spec) parameterArray[0];
       labels.add(spec.name());
     }
-
-  }
-
-  private Collection<Object[]> getParameterArrays() throws Exception {
-    Method testClassMethod = getDeclaredMethod(this.getClass(),
-        "getTestClass");
-    Class<?> returnType = testClassMethod.getReturnType();
-    if (returnType == Class.class) {
-      return getParameterArrays4_3();
-    } else {
-      return getParameterArrays4_4();
-    }
-  }
-
-  private Collection<Object[]> getParameterArrays4_3() throws Exception {
-    Object[][] methodCalls = new Object[][] {new Object[] {"getTestClass" } };
-    Class<?> cl = invokeMethodChain(this, methodCalls);
-    Method[] methods = cl.getMethods();
-
-    Method parametersMethod = null;
-    for (Method method : methods) {
-      boolean providesParameters = method
-          .isAnnotationPresent(Parameters.class);
-      if (!providesParameters) {
-        continue;
-      }
-
-      if (parametersMethod != null) {
-        throw new Exception(
-            "Only one method should be annotated with @Labels");
-      }
-
-      parametersMethod = method;
-    }
-
-    if (parametersMethod == null) {
-      throw new Exception("No @Parameters method found");
-    }
-
-    @SuppressWarnings("unchecked")
-    Collection<Object[]> parameterArrays =
-        (Collection<Object[]>) parametersMethod
-            .invoke(null);
-    return parameterArrays;
-
-  }
-
-  private Collection<Object[]> getParameterArrays4_4() throws Exception {
-    Object[][] methodCalls = new Object[][] {
-        new Object[] {"getTestClass" },
-        new Object[] {"getAnnotatedMethods", Class.class,
-            Parameters.class },
-        new Object[] {"get", int.class, 0 },
-        // use array type for varargs (equivalent (almost))
-        new Object[] {"invokeExplosively", Object.class, null,
-            Object[].class, new Object[] {} } };
-    Collection<Object[]> parameterArrays = invokeMethodChain(this,
-        methodCalls);
-    return parameterArrays;
   }
 
   @SuppressWarnings("unchecked")
-  private <T> T invokeMethodChain(Object object, final Object[][] methodCalls)
-      throws Exception {
-    for (Object[] methodCall : methodCalls) {
-      String methodName = (String) methodCall[0];
-      int parameterCount = (methodCall.length - 1) / 2;
-      Class<?>[] classes = new Class<?>[parameterCount];
-      Object[] arguments = new Object[parameterCount];
-      for (int i = 1; i < methodCall.length; i += 2) {
-        Class<?> cl = (Class<?>) methodCall[i];
-        Object argument = methodCall[i + 1];
-        int index = (i - 1) / 2; // messy!
-        classes[index] = cl;
-        arguments[index] = argument;
-      }
-      Method method = getDeclaredMethod(object.getClass(), methodName,
-          classes);
-      method.setAccessible(true);
-      object = method.invoke(object, arguments);
-    }
-    return (T) object;
-  }
-
-  // iterates through super-classes until found. Throws NoSuchMethodException
-  // if not
-  private Method getDeclaredMethod(Class<?> cl, final String methodName,
-      final Class<?>... parameterTypes) throws NoSuchMethodException {
-    do {
-      try {
-        Method method = cl
-            .getDeclaredMethod(methodName, parameterTypes);
-        return method;
-      } catch (NoSuchMethodException e) {
-        // do nothing - just fall through to the below
-      }
-      cl = cl.getSuperclass();
-    } while (cl != null);
-    throw new NoSuchMethodException("Method " + methodName
-        + "() not found in hierarchy");
+  private Collection<Object[]> getParameterArrays4_4() throws Throwable {
+    TestClass testClass = this.getTestClass();
+    List<FrameworkMethod> annotatedMethods = testClass.getAnnotatedMethods(Parameters.class);
+    FrameworkMethod frameworkMethod = annotatedMethods.get(0);
+    return (Collection<Object[]>)frameworkMethod.invokeExplosively(testClass);
   }
 
   private void generateLabelledDescription() throws Exception {
     Description originalDescription = super.getDescription();
     labelledDescription = Description
         .createSuiteDescription(originalDescription.getDisplayName());
-    ArrayList<Description> childDescriptions = originalDescription
+    List<Description> childDescriptions = originalDescription
         .getChildren();
     int childCount = childDescriptions.size();
     if (childCount != labels.size()) {
@@ -163,7 +70,7 @@ public class SpecRunner extends Parameterized {
       String label = labels.get(i);
       Description newDescription = Description
           .createSuiteDescription(label);
-      ArrayList<Description> grandChildren = childDescription
+      List<Description> grandChildren = childDescription
           .getChildren();
       for (Description grandChild : grandChildren) {
         newDescription.addChild(grandChild);
@@ -176,5 +83,4 @@ public class SpecRunner extends Parameterized {
   public Description getDescription() {
     return labelledDescription;
   }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -159,31 +159,11 @@
       </dependency>
 
       <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>4.2</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-easymock</artifactId>
-        <version>2.0.7</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>2.0.7</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>3.12.0</version>
         <scope>test</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,13 +84,13 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
-        <version>3.1.1.RELEASE</version>
+        <version>5.1.10.RELEASE</version>
       </dependency>
 
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
-        <version>3.1.1.RELEASE</version>
+        <version>5.1.10.RELEASE</version>
         <scope>test</scope>
       </dependency>
 
@@ -169,13 +169,11 @@
 
   <build>
     <plugins>
-      <!-- We're on 1.8 -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
         </configuration>
       </plugin>
 
@@ -393,10 +391,6 @@
       </build>
     </profile>
   </profiles>
-
-  <prerequisites>
-    <maven>3.0</maven>
-  </prerequisites>
 
   <properties>
     <!-- Encoding UTF-8 -->


### PR DESCRIPTION
This should make handlebars.java work with Java 15+.

The only thing that does not work currently is handlebars-markdown. This has a dependency to [pegdown](https://github.com/sirthias/pegdown) which in turn has a dependency to parboiled where you can find this [issue](https://github.com/sirthias/parboiled/issues/175). 
Of course we could replace the dependency with something like [flexmark-java](https://github.com/vsch/flexmark-java) (as recommended in the pegdown readme). But as I don't know whether handlebars-markdown is used anywhere at all (or what it really does - it is just a single class with barely 15 lines of code in it), I didn't want to invest (and probably waste) the time and effort.
