### PR TITLE
Partial fix of Illegal Access

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
@@ -149,7 +149,7 @@ public class Context {
       super(model);
       this.extendedContext = new Context(hash);
       this.extendedContext.resolver = parent.resolver;
-      this.extendedContext.extendedContext = new Context(Collections.emptyMap());
+      this.extendedContext.extendedContext = new Context(new HashMap<String, Object>());
       this.parent = parent;
       this.data = parent.data;
       this.resolver = parent.resolver;


### PR DESCRIPTION
This is a partial fix for https://github.com/jknack/handlebars.java/issues/667

I was finding that java.util.Collections$EmptyMap is a private class, so in newer JDK's attempting to make its isEmpty method accessible would fail.

The simple act of using partials caused this exception to happen in recent JDK's.