### PR TITLE
Issues/667/illegal access

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [1.8]
+        java_version: [1.8, 17]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/Jackson2HelperTest.java
+++ b/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/Jackson2HelperTest.java
@@ -40,7 +40,7 @@ public class Jackson2HelperTest {
 
     Template template = handlebars.compileInline("{{@json this}}");
 
-    CharSequence result = template.apply(new Blog("First Post", "..."));
+    CharSequence result = template.apply(new Blog("First Post", "...")).trim();
 
     assertEquals("{\"title\":\"First Post\",\"body\":\"...\",\"comments\":[]}",
         result);
@@ -53,7 +53,7 @@ public class Jackson2HelperTest {
 
     Template template = handlebars.compileInline("{{@json this pretty=true}}");
 
-    CharSequence result = template.apply(new Blog("First Post", "..."));
+    CharSequence result = template.apply(new Blog("First Post", "...")).trim();
 
     assertEquals("{\n" +
         "  \"title\" : \"First Post\",\n" +
@@ -73,7 +73,7 @@ public class Jackson2HelperTest {
         handlebars
             .compileInline("{{@json this view=\"com.github.jknack.handlebars.Blog$Views$Public\"}}");
 
-    CharSequence result = template.apply(new Blog("First Post", "..."));
+    CharSequence result = template.apply(new Blog("First Post", "...")).trim();
 
     assertEquals("{\"title\":\"First Post\",\"body\":\"...\",\"comments\":[]}",
         result);
@@ -92,7 +92,7 @@ public class Jackson2HelperTest {
         handlebars
             .compileInline("{{@json this view=\"com.github.jknack.handlebars.Blog$Views$Public\"}}");
 
-    CharSequence result = template.apply(new Blog("First Post", "..."));
+    CharSequence result = template.apply(new Blog("First Post", "...")).trim();
 
     assertEquals("{\"title\":\"First Post\"}", result);
   }
@@ -111,7 +111,7 @@ public class Jackson2HelperTest {
         handlebars
             .compileInline("{{@json this view=\"myView\"}}");
 
-    CharSequence result = template.apply(new Blog("First Post", "..."));
+    CharSequence result = template.apply(new Blog("First Post", "...")).trim();
 
     assertEquals("{\"title\":\"First Post\"}", result);
   }
@@ -129,7 +129,7 @@ public class Jackson2HelperTest {
         handlebars
             .compileInline("{{@json this view=\"missing.ViewClass\"}}");
 
-    CharSequence result = template.apply(new Blog("First Post", "..."));
+    CharSequence result = template.apply(new Blog("First Post", "...")).trim();
 
     assertEquals("{\"title\":\"First Post\"}", result);
   }
@@ -143,10 +143,10 @@ public class Jackson2HelperTest {
     model.put("script", "<script text=\"text/javascript\"></script>");
 
     assertEquals("{\"script\":\"<script text=\\\"text/javascript\\\"></script>\"}", handlebars
-        .compileInline("{{@json this}}").apply(model));
+        .compileInline("{{@json this}}").apply(model).trim());
 
     assertEquals(
         "{\"script\":\"\\u003Cscript text=\\\"text/javascript\\\"\\u003E\\u003C/script\\u003E\"}",
-        handlebars.compileInline("{{@json this escapeHTML=true}}").apply(model));
+        handlebars.compileInline("{{@json this escapeHTML=true}}").apply(model).trim());
   }
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
@@ -78,7 +78,7 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
       Set<M> members = members(clazz);
       for (M m : members) {
         // Mark as accessible.
-        if (m instanceof AccessibleObject) {
+        if (isUseSetAccessible(m) && m instanceof AccessibleObject) {
           ((AccessibleObject) m).setAccessible(true);
         }
         mcache.put(memberName(m), m);
@@ -86,6 +86,31 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
       this.cache.put(clazz, mcache);
     }
     return mcache;
+  }
+  
+  /**
+   * Determines whether or not to call
+   * {@link AccessibleObject#setAccessible(boolean)} on members before they are
+   * cached.
+   * 
+   * Calling setAccessible on JDK 9 or later on private or protected declaring
+   * classes in modules will result in errors so the default implementation checks
+   * to see if the declared class cannonical name starts with "java." or "sun." to
+   * prevent most of these errors.
+   * 
+   * Modular applications should create their own resolvers and override this
+   * method to prevent encapsulation violation errors.
+   * 
+   * @param member Not null.
+   * @return true will cause setAccessible(true) to be called.
+   */
+  protected boolean isUseSetAccessible(M member) {
+    Class<?> dc = member.getDeclaringClass();
+    String dn;
+    if (dc != null && (dn = dc.getCanonicalName()) != null && (dn.startsWith("java.") || dn.startsWith("sun."))) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/handlebars/src/test/java/com/github/jknack/handlebars/IgnoreWindowsLineMatcher.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/IgnoreWindowsLineMatcher.java
@@ -1,0 +1,28 @@
+package com.github.jknack.handlebars;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class IgnoreWindowsLineMatcher extends TypeSafeMatcher<String> {
+
+  private String value;
+
+  private IgnoreWindowsLineMatcher(String value) {
+    this.value = value;
+  }
+
+  public static IgnoreWindowsLineMatcher equalsToStringIgnoringWindowsNewLine(String value) {
+    return new IgnoreWindowsLineMatcher(value);
+  }
+
+  @Override protected boolean matchesSafely(String item) {
+    return item.replace("\r\n", "\n").equals(value);
+  }
+
+  @Override public void describeTo(Description description) {
+    description.appendText("a string ")
+        .appendText("ignoring \\r")
+        .appendText(" ")
+        .appendValue(value);
+  }
+}

--- a/handlebars/src/test/java/com/github/jknack/handlebars/TemporalPartialTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/TemporalPartialTest.java
@@ -1,6 +1,6 @@
 package com.github.jknack.handlebars;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -34,12 +34,13 @@ public class TemporalPartialTest {
       }
     });
     Template template = handlebars.compile("temporal-partials");
-    assertEquals("Items:\n" +
-        "\n" +
-        "Item: Custom\n" +
-        "...\n" +
-        "Item: 2\n" +
-        "...\n", template.apply(Arrays.asList(new Item("1"), new Item("2"))));
+    assertThat(template.apply(Arrays.asList(new Item("1"), new Item("2"))),
+        IgnoreWindowsLineMatcher.equalsToStringIgnoringWindowsNewLine("Items:\n" +
+            "\n" +
+            "Item: Custom\n" +
+            "...\n" +
+            "Item: 2\n" +
+            "...\n"));
   }
 
   @Test
@@ -47,17 +48,18 @@ public class TemporalPartialTest {
     Handlebars handlebars = new Handlebars();
     handlebars.setPrettyPrint(true);
     Template template = handlebars.compile("derived");
-    assertEquals("\n" +
-        "<html>\n" +
-        "<head>\n" +
-        "  <title>\n" +
-        "     Home \n" +
-        "  </title>\n" +
-        "</head>\n" +
-        "<body>\n" +
-        "  <h1> Home </h1>\n" +
-        "  HOME\n" +
-        "</body>\n" +
-        "</html>", template.apply(null));
+    assertThat(template.apply(null),
+        IgnoreWindowsLineMatcher.equalsToStringIgnoringWindowsNewLine("\n" +
+            "<html>\n" +
+            "<head>\n" +
+            "  <title>\n" +
+            "     Home \n" +
+            "  </title>\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "  <h1> Home </h1>\n" +
+            "  HOME\n" +
+            "</body>\n" +
+            "</html>"));
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/context/SetAccessibleValueResolverTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/context/SetAccessibleValueResolverTest.java
@@ -1,0 +1,58 @@
+package com.github.jknack.handlebars.context;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class SetAccessibleValueResolverTest {
+
+  /*
+   * The following tests require JDK 9 or greater.
+   * To keep the tests from failing we use junit assume.
+   */
+
+  @Test
+  public void testSetAccessibleOnJDK9OrGreater() throws Exception {
+    assumeTrue(getJavaVersion() >= 9);
+    MethodValueResolver mv = new MethodValueResolver() {
+
+      @Override
+      protected boolean isUseSetAccessible(Method m) {
+        return true;
+      }
+    };
+    try {
+      mv.resolve(Collections.emptyMap(), "doesNotMatter");
+      fail("Expect InaccessibleObjectException");
+    } catch (/* InaccessibleObjectException */ Exception e) {
+    }
+
+    mv = new MethodValueResolver();
+    mv.resolve(Collections.emptyMap(), "doesNotMatter");
+    Object result = mv.resolve(Collections.emptyMap(), "isEmpty");
+    assertEquals(Boolean.TRUE, result);
+  }
+
+  static int getJavaVersion() {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("1.")) {
+      version = version.substring(2, 3);
+    } else {
+      int dot = version.indexOf(".");
+      if (dot != -1) {
+        version = version.substring(0, dot);
+      }
+    }
+    try {
+      return Integer.parseInt(version);
+    } catch (NumberFormatException e) {
+      return 8;
+    }
+  }
+
+}

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i275/Issue275.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i275/Issue275.java
@@ -1,6 +1,6 @@
 package com.github.jknack.handlebars.i275;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.IgnoreWindowsLineMatcher;
 import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
@@ -41,12 +42,13 @@ public class Issue275 {
       }
     });
     Template template = handlebars.compile("temporal-partials");
-    assertEquals("Items:\n" +
-        "\n" +
-        "Item: Custom\n" +
-        "...\n" +
-        "Item: 2\n" +
-        "...\n", template.apply(Arrays.asList(new Item("1"), new Item("2"))));
+    assertThat(template.apply(Arrays.asList(new Item("1"), new Item("2"))),
+        IgnoreWindowsLineMatcher.equalsToStringIgnoringWindowsNewLine("Items:\n" +
+            "\n" +
+            "Item: Custom\n" +
+            "...\n" +
+            "Item: 2\n" +
+            "...\n"));
   }
 
   @Test
@@ -63,11 +65,12 @@ public class Issue275 {
       }
     });
     Template template = handlebars.compile("temporal-partials");
-    assertEquals("Items:\n" +
-        "\n" +
-        "Item: Custom\n" +
-        "...\n" +
-        "Item: Custom\n" +
-        "...\n", template.apply(Arrays.asList(new Item("1"), new Item("2"))));
+    assertThat(template.apply(Arrays.asList(new Item("1"), new Item("2"))),
+        IgnoreWindowsLineMatcher.equalsToStringIgnoringWindowsNewLine("Items:\n" +
+            "\n" +
+            "Item: Custom\n" +
+            "...\n" +
+            "Item: Custom\n" +
+            "...\n"));
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs507.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/issues/Hbs507.java
@@ -1,6 +1,6 @@
 package com.github.jknack.handlebars.issues;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.Map;
@@ -10,13 +10,14 @@ import org.junit.Test;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.IgnoreWindowsLineMatcher;
 import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.Template;
-import com.github.jknack.handlebars.v4Test;
 import com.github.jknack.handlebars.cache.HighConcurrencyTemplateCache;
 import com.github.jknack.handlebars.cache.NullTemplateCache;
 import com.github.jknack.handlebars.cache.TemplateCache;
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import com.github.jknack.handlebars.v4Test;
 
 public class Hbs507 extends v4Test {
 
@@ -61,19 +62,19 @@ public class Hbs507 extends v4Test {
         $("aggregateId", "ID:y0", "aggregateType", "brett", "businessKey", "favre"));
 
     Template template = handlebars.compile("a");
-    assertEquals("This is a test for: \"ID:x0\"\n" +
+    assertThat(template.apply(h1), IgnoreWindowsLineMatcher.equalsToStringIgnoringWindowsNewLine("This is a test for: \"ID:x0\"\n" +
         "\n" +
         "\"metadata.aggregateId\" : \"ID:x0\" \n" +
         "\"metadata.businessKey\" : \"favre\"\n" +
         "\n" +
-        "End test", template.apply(h1));
+        "End test"));
 
-    assertEquals("This is a test for: \"ID:y0\"\n" +
+    assertThat(template.apply(h2), IgnoreWindowsLineMatcher.equalsToStringIgnoringWindowsNewLine("This is a test for: \"ID:y0\"\n" +
         "\n" +
         "\"metadata.aggregateId\" : \"ID:y0\" \n" +
         "\"metadata.businessKey\" : \"favre\"\n" +
         "\n" +
-        "End test", template.apply(h2));
+        "End test"));
   }
 
 }


### PR DESCRIPTION
This is to fix #667 

I think this is the safest fix for now. 

Basically I just check to see if the declaring class name starts with "java." or "sun." and if it does not to call setAccessible. 

It's also extendable now so custom MemberValueResolvers can change the logic.