### PR TITLE
Allow for null arguments to be passed again.

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/MethodHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/MethodHelper.java
@@ -72,7 +72,7 @@ public class MethodHelper implements Helper<Object> {
           if (paramTypes[i] == Options.class) {
             args[i] = options;
           } else {
-            args[i] = options.param(i - 1);
+            args[i] = options.param(i - 1, null);
           }
         }
       }


### PR DESCRIPTION
In order versions, This used to allow for nulls to be passed as an argument if it was not found in the options. This would add that functionality back.