### PR TITLE
Fix invalid Java token error in README.md (replace keyword class with classParam)

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,8 +544,8 @@ Template template = handlebars.compileInline("{{#blog-list blogs}}{{/blog-list}}
 ```java
 handlebars.registerHelper("blog-list", new Helper<Blog>() {
   public CharSequence apply(List<Blog> list, Options options) {
-    String class = options.hash("class");
-    assertEquals("blog-css", class);
+    String classParam = options.hash("class");
+    assertEquals("blog-css", classParam);
     ...
   }
 });


### PR DESCRIPTION
* class is a reserved keyword in java code which leads to a compile error when copy pasting this code example