### PR TITLE
Java-Version detection for Android

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -248,7 +248,11 @@ public class Handlebars implements HelperRegistry {
 
     static int javaVersion() {
       String version = System.getProperty("java.specification.version").trim();
-      return Integer.parseInt(version.replace(VERSION_PREFIX, ""));
+      try {
+        return Integer.parseInt(version.replace(VERSION_PREFIX, ""));
+      } catch(NumberFormatException exception) {
+        return 8;
+      }
     }
 
     /**


### PR DESCRIPTION
On the Android OS the Java specification version is hardcoded to "0.9". This leads to the current Java Version method failing. Since only 1.x prefix versions are cut away the current method fails to parse a float. This fix suggests falling back to 8 when the number could not be parsed (making it generally more resilient for ill-specified java versions).

Another way to solve this includes working with floats instead of ints, but since `Handlebars.Utils.javaVersion` is public, this would be a breaking change and thus was not considered.