### PR TITLE
Return null on illegal field acces

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/FieldValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/FieldValueResolver.java
@@ -212,6 +212,10 @@ public class FieldValueResolver extends MemberValueResolver<FieldWrapper> {
   protected Object invokeMember(final FieldWrapper field, final Object context) {
     try {
       return field.get(context);
+    } catch (IllegalAccessException ex) {
+      System.err.println("Illegal access to field '" + field.getName() +
+        "'. Returning null instead.");
+      return null;
     } catch (Exception ex) {
       throw new IllegalStateException(
           "Shouldn't be illegal to access field '" + field.getName()


### PR DESCRIPTION
This seems to fix issue #940 without breaking any test.

In a nutshell, an IllegalAccessException is now expected when trying to access fields not exported by a module through reflexion.