### PR TITLE
Issues/951/upgrades breaking

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/ValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/ValueResolver.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import com.github.jknack.handlebars.context.JavaBeanValueResolver;
 import com.github.jknack.handlebars.context.MapValueResolver;
-import com.github.jknack.handlebars.context.MethodValueResolver;
+import com.github.jknack.handlebars.context.RecordValueResolver;
 
 /**
  * A hook interface for resolving values from the {@link Context context stack}.
@@ -79,15 +79,12 @@ public interface ValueResolver {
    *
    * - {@link MapValueResolver}
    * - {@link JavaBeanValueResolver}
-   * - {@link MethodValueResolver}. On Java 14 or higher.
+   * - {@link RecordValueResolver}.
    *
    * @return Immutable list of value resolvers.
    */
   static List<ValueResolver> defaultValueResolvers() {
-    if (Handlebars.Utils.javaVersion14) {
-      return unmodifiableList(asList(MapValueResolver.INSTANCE,
-          JavaBeanValueResolver.INSTANCE, MethodValueResolver.INSTANCE));
-    }
-    return unmodifiableList(asList(MapValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE));
+    return unmodifiableList(
+        asList(MapValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE, RecordValueResolver.INSTANCE));
   }
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/ValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/ValueResolver.java
@@ -85,6 +85,9 @@ public interface ValueResolver {
    */
   static List<ValueResolver> defaultValueResolvers() {
     return unmodifiableList(
-        asList(MapValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE, RecordValueResolver.INSTANCE));
+        asList(
+            MapValueResolver.INSTANCE,
+            JavaBeanValueResolver.INSTANCE,
+            RecordValueResolver.INSTANCE));
   }
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
@@ -50,6 +50,9 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
 
   @Override
   public final Object resolve(final Object context, final String name) {
+    if (! matches(context)) {
+      return UNRESOLVED;
+    }
     Class<?> key = context.getClass();
     Map<String, M> mcache = cache(key);
     M member = mcache.get(name);
@@ -59,7 +62,7 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
       return invokeMember(member, context);
     }
   }
-
+  
   @Override
   public Object resolve(final Object context) {
     return UNRESOLVED;
@@ -122,6 +125,16 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
    */
   protected abstract Object invokeMember(M member, Object context);
 
+  /**
+   * True, if the context is worth examing by this resolver.
+   *
+   * @param context The context object.
+   * @return True, if the context is suitable.
+   */
+  protected boolean matches(Object context) {
+    return true;
+  }
+  
   /**
    * True, if the member matches the one we look for.
    *

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/MemberValueResolver.java
@@ -50,7 +50,7 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
 
   @Override
   public final Object resolve(final Object context, final String name) {
-    if (! matches(context)) {
+    if (!matches(context)) {
       return UNRESOLVED;
     }
     Class<?> key = context.getClass();
@@ -62,7 +62,7 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
       return invokeMember(member, context);
     }
   }
-  
+
   @Override
   public Object resolve(final Object context) {
     return UNRESOLVED;
@@ -131,10 +131,10 @@ public abstract class MemberValueResolver<M extends Member> implements ValueReso
    * @param context The context object.
    * @return True, if the context is suitable.
    */
-  protected boolean matches(Object context) {
+  protected boolean matches(final Object context) {
     return true;
   }
-  
+
   /**
    * True, if the member matches the one we look for.
    *

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/RecordValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/RecordValueResolver.java
@@ -18,7 +18,7 @@ public class RecordValueResolver extends MethodValueResolver {
   @Override
   protected boolean matches(final Object context) {
     Class<?> superClass = context.getClass().getSuperclass();
-    return superClass.getName().equals("java.lang.Record");
+    return superClass != null && superClass.getName().equals("java.lang.Record");
   }
 
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/RecordValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/RecordValueResolver.java
@@ -1,0 +1,21 @@
+package com.github.jknack.handlebars.context;
+
+/**
+ * A resolver for Record types.
+ * 
+ * This resolver is safe to use in JDKs that do not support records yet.
+ * 
+ * @author agentgt
+ *
+ */
+public class RecordValueResolver extends MethodValueResolver {
+
+  public static RecordValueResolver INSTANCE = new RecordValueResolver();
+  
+  @Override
+  protected boolean matches(Object context) {
+    Class<?> superClass = context.getClass().getSuperclass();
+    return superClass.getName().equals("java.lang.Record");
+  }
+
+}

--- a/handlebars/src/main/java/com/github/jknack/handlebars/context/RecordValueResolver.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/context/RecordValueResolver.java
@@ -2,18 +2,21 @@ package com.github.jknack.handlebars.context;
 
 /**
  * A resolver for Record types.
- * 
+ *
  * This resolver is safe to use in JDKs that do not support records yet.
- * 
+ *
  * @author agentgt
  *
  */
 public class RecordValueResolver extends MethodValueResolver {
 
-  public static RecordValueResolver INSTANCE = new RecordValueResolver();
-  
+  /**
+   * The default instance.
+   */
+  public static final RecordValueResolver INSTANCE = new RecordValueResolver();
+
   @Override
-  protected boolean matches(Object context) {
+  protected boolean matches(final Object context) {
     Class<?> superClass = context.getClass().getSuperclass();
     return superClass.getName().equals("java.lang.Record");
   }


### PR DESCRIPTION
@jknack The solution in 4.3.0 for allowing records in #826 of checking java version and then adding the method value resolver is flawed in my opinion and is going to continue to cause bugs like #951 

This pull request effectively makes records work by default for folks using new JDKs while still allowing existing previous users using `defaultValueResolvers` to have templates that behave the same.

I highly recommend we try to get this in a release soon to minimize the window that folks will not inherently rely on methods being resolved by default (ie the users who just started using handlebars picking 4.3.0 and relying on the flawed default behavior).