### PR TITLE
Unwrap Jackson2 ArrayNode in JsonNodeValueResolver (#964)

### DIFF
--- a/handlebars-jackson2/src/main/java/com/github/jknack/handlebars/JsonNodeValueResolver.java
+++ b/handlebars-jackson2/src/main/java/com/github/jknack/handlebars/JsonNodeValueResolver.java
@@ -17,11 +17,13 @@
  */
 package com.github.jknack.handlebars;
 
+import java.util.AbstractList;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -84,7 +86,7 @@ public enum JsonNodeValueResolver implements ValueResolver {
    * Resolve a {@link JsonNode} object to a primitive value.
    *
    * @param node A {@link JsonNode} object.
-   * @return A primitive value, json object, json array or null.
+   * @return A primitive value, json object as a map, json array as a list, or null.
    */
   private static Object resolve(final JsonNode node) {
     // binary node
@@ -127,7 +129,12 @@ public enum JsonNodeValueResolver implements ValueResolver {
     if (node instanceof ObjectNode) {
       return toMap((ObjectNode) node);
     }
-    // container, array or null
+    // array node to list
+    if (node instanceof ArrayNode) {
+      return toList((ArrayNode) node);
+    }
+
+    // container or literal null
     return node;
   }
 
@@ -156,6 +163,21 @@ public enum JsonNodeValueResolver implements ValueResolver {
           set.add(it.next());
         }
         return set;
+      }
+    };
+  }
+
+  private static List<Object> toList(final ArrayNode node) {
+    return new AbstractList<Object>() {
+
+      @Override
+      public Object get(int index) {
+        return resolve(node.get(index));
+      }
+
+      @Override
+      public int size() {
+        return node.size();
       }
     };
   }

--- a/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/Issue964.java
+++ b/handlebars-jackson2/src/test/java/com/github/jknack/handlebars/Issue964.java
@@ -1,0 +1,67 @@
+package com.github.jknack.handlebars;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.jknack.handlebars.context.MapValueResolver;
+import com.github.jknack.handlebars.helper.StringHelpers;
+
+import org.junit.Test;
+
+public class Issue964 extends AbstractTest {
+
+    @Override
+    protected Object configureContext(final Object model) {
+      return Context.newBuilder(model)
+          .resolver(MapValueResolver.INSTANCE, JsonNodeValueResolver.INSTANCE)
+          .build();
+    }
+
+    @Test
+    public void shouldUnwrapJsonArraysAsIterables() throws IOException {
+      Hash helpers = $("join", StringHelpers.join);
+      JsonNode tree = new ObjectMapper().readTree("{\"pets\":[\"cat\",\"dog\",\"bird\"]}");
+      shouldCompileTo("{{join this.pets \", \"}}", tree, helpers, "cat, dog, bird");
+    }
+
+    @Test
+    public void shouldUnwrapJsonArraysByIndex() throws IOException {
+      Hash helpers = $("join", StringHelpers.join);
+      JsonNode tree = new ObjectMapper().readTree("{\"pets\":[\"cat\",\"dog\",\"bird\"]}");
+      shouldCompileTo("{{join this.pets.[0] this.pets.[1] this.pets.[2] \", \"}}", tree, helpers, "cat, dog, bird");
+    }
+
+    @Test
+    public void shouldUnwrapJsonArraysRecursively() throws IOException {
+      Hash helpers = $("elementAt", new ElementAtHelper(), "capitalize", StringHelpers.capitalize);
+      JsonNode tree = new ObjectMapper().readTree("{\"kidsPets\":[[\"cat\",\"dog\"],[\"bird\",\"mouse\"]]}");
+      shouldCompileTo("{{capitalize (elementAt (elementAt this.kidsPets 0) 1)}}", tree, helpers, "Dog");
+    }
+
+    private static class ElementAtHelper implements Helper<Iterable<Object>> {
+
+      @Override
+      public Object apply(Iterable<Object> context, Options options) throws IOException {
+        int targetIndex = options.param(0);
+        int currentIndex = 0;
+
+        Iterator<Object> loop = context.iterator();
+
+        while (loop.hasNext()) {
+          Object it = loop.next();
+          if (currentIndex++ == targetIndex) {
+            return it;
+          }
+        }
+
+        throw new IOException(
+          "Cannot get element at " + targetIndex + ". " +
+          "Iterable only has " + currentIndex + " elements."
+        );
+      }
+
+    }
+
+}


### PR DESCRIPTION
#### Background

This is a fix for self-reported issue #964. Now the `JsonNodeValueResolver` resolves a Jackson2 `ArrayNode` as a `List<Object>` with its items being recursively resolved.

I wrote it in the same style as the `JsonNodeValueResolver.toObject()`, meaning:
- It uses a closure as a reference the original `JsonNode`.
- It uses an abstract collection as the base implementation of the list.
- It only implements the retrieval methods on the abstract collection.
- It performs the recursive resolution lazily.

#### Testing

I wrote a few unit tests to verify the behavior works as expected. All of the existing unit tests pass without issue.