### PR TITLE
Add identity helper

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/HelperRegistry.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/HelperRegistry.java
@@ -81,6 +81,7 @@ public interface HelperRegistry {
 
   /**
    * Register the special helper missing in the registry.
+   * Default behaviour is throwing exception on missing helper.
    *
    * @param <H> The helper runtime type.
    * @param helper The helper object. Required.

--- a/handlebars/src/main/java/com/github/jknack/handlebars/helper/IdentityHelper.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/helper/IdentityHelper.java
@@ -1,0 +1,15 @@
+package com.github.jknack.handlebars.helper;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+/**
+ * Mainly used with {@link com.github.jknack.handlebars.HelperRegistry#registerHelperMissing}.
+ * Use case example: Applying multiple handlebars implementations with different helpers.
+ */
+public class IdentityHelper implements Helper<Object> {
+    @Override
+    public Object apply(Object context, Options options) {
+        return options.fn.text();
+    }
+}


### PR DESCRIPTION
Currently, when there is a missing helper, the default behavior is throwing an exception.
There is a function 'registerHelperMissing' to allow override it.

In microservice architecture where each microservice has only its own data, each MS (microservice) has different handlebars implementation with its own helper functions.
In this example, we want to leave missing helpers as is so it might be handled down the road.