### PR TITLE
GH-1009: update Apache Commons Text to 1.10.0 (Fix CVE-2022-42889)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.9</version>
+        <version>1.10.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fix CVE-2022-42889

Note that Apache Commons Text is packaged as a shaded dependency.


----

We are a happy user of the Handlebars library. The current version of handlebars appears in different vulnerability scanners due to the above mentioned CVE. This change updates the commons-text dependency to the latest non-affected version.