### PR TITLE
removed shaded org.apache.commons.text

### DIFF
--- a/handlebars/pom.xml
+++ b/handlebars/pom.xml
@@ -44,10 +44,6 @@
                   <shadedPattern>com.github.jknack.handlebars.internal.lang3</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.commons.text</pattern>
-                  <shadedPattern>com.github.jknack.handlebars.internal.text</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.antlr.v4.runtime</pattern>
                   <shadedPattern>com.github.jknack.handlebars.internal.antlr</shadedPattern>
                 </relocation>


### PR DESCRIPTION
Follow up on https://github.com/jknack/handlebars.java/pull/1010.
Removing the shaded `org.apache.commons.commons-text` that might trigger scanners related to `CVE-2022-42889`.

Discussion: https://github.com/jknack/handlebars.java/issues/1009