### PR TITLE
Improve handlebars performance on large templates

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
@@ -110,7 +110,7 @@ abstract class BaseTemplate implements Template {
 
   @Override
   public String apply(final Context context) throws IOException {
-    FastStringWriter writer = new FastStringWriter();
+    FastStringWriter writer = new FastStringWriter(text().length());
     apply(context, writer);
     return writer.toString();
   }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/FastStringWriter.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/FastStringWriter.java
@@ -17,8 +17,6 @@
  */
 package com.github.jknack.handlebars.internal;
 
-import org.apache.commons.text.TextStringBuilder;
-
 import java.io.IOException;
 import java.io.Writer;
 
@@ -39,10 +37,18 @@ class FastStringWriter extends Writer {
     BUFFER_SIZE = Integer.parseInt(System.getProperty("hbs.buffer", "1600"));
   }
 
+  FastStringWriter() {
+    this(BUFFER_SIZE);
+  }
+
+  FastStringWriter(final int capacity) {
+    this.buffer = new StringBuilder(capacity);
+  }
+
   /**
    * The internal buffer.
    */
-  private TextStringBuilder buffer = new TextStringBuilder(BUFFER_SIZE);
+  private final StringBuilder buffer;
 
   @Override
   public Writer append(final char c) throws IOException {
@@ -63,29 +69,27 @@ class FastStringWriter extends Writer {
   }
 
   @Override
-  public void write(final char[] buffer) throws IOException {
+  public void write(final char[] buffer) {
     this.buffer.append(buffer);
   }
 
   @Override
-  public void write(final int c) throws IOException {
+  public void write(final int c) {
     this.buffer.append((char) c);
   }
 
   @Override
-  public void write(final String str) throws IOException {
+  public void write(final String str) {
     this.buffer.append(str);
   }
 
   @Override
-  public void write(final String str, final int off, final int len)
-      throws IOException {
-    buffer.append(str, off, len);
+  public void write(final String str, final int off, final int len) {
+    buffer.append(str, off, off + len);
   }
 
   @Override
-  public void write(final char[] buffer, final int off, final int len)
-      throws IOException {
+  public void write(final char[] buffer, final int off, final int len) {
     if (off < 0 || off > buffer.length || len < 0
         || off + len > buffer.length || off + len < 0) {
       throw new IndexOutOfBoundsException();
@@ -96,12 +100,11 @@ class FastStringWriter extends Writer {
   }
 
   @Override
-  public void flush() throws IOException {
+  public void flush() {
   }
 
   @Override
-  public void close() throws IOException {
-    buffer = null;
+  public void close() {
   }
 
   @Override

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/VarParam.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/VarParam.java
@@ -43,7 +43,7 @@ public class VarParam implements Param {
 
   @Override
   public Object apply(final Context context) throws IOException {
-    return this.fn.value(context, new FastStringWriter());
+    return this.fn.value(context, new FastStringWriter(fn.text().length()));
   }
 
   @Override

--- a/handlebars/src/test/java/com/github/jknack/handlebars/bench/LargeHbsBench.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/bench/LargeHbsBench.java
@@ -1,0 +1,64 @@
+package com.github.jknack.handlebars.bench;
+
+import com.github.jknack.handlebars.Handlebars.SafeString;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.bench.Bench.Unit;
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+public class LargeHbsBench {
+
+  private Map<String, Object> context;
+
+  private Template template;
+
+  @Before
+  public void setup() throws IOException {
+    Assume.assumeTrue(Boolean.valueOf(System.getProperty("run.bench")));
+
+    template = new com.github.jknack.handlebars.Handlebars(
+        new ClassPathTemplateLoader("/", ".html"))
+            .registerHelper("minus", new Helper<Stock>() {
+              @Override
+              public Object apply(final Stock stock, final Options options)
+                  throws IOException {
+                return stock.getChange() < 0 ? new SafeString("class=\"minus\"") : null;
+              }
+            }).compile("com/github/jknack/handlebars/bench/large.hbs");
+    this.context = new HashMap<>();
+    this.context.put("items", IntStream.range(100000, 200000).boxed().collect(toList()));
+  }
+
+  @Test
+  public void single() throws IOException {
+    template.apply(context);
+  }
+
+  @Test
+  public void benchmark() throws IOException {
+    new Bench(1000, 5, 30).run(new Unit() {
+
+      @Override
+      public void run() throws IOException {
+        template.apply(context);
+      }
+
+      @Override
+      public String toString() {
+        return "large.hbs";
+      }
+    });
+
+  }
+}

--- a/handlebars/src/test/resources/com/github/jknack/handlebars/bench/large.hbs.html
+++ b/handlebars/src/test/resources/com/github/jknack/handlebars/bench/large.hbs.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Large page</title>
+</head>
+
+<body>
+{{#each items as |item|}}
+<p>
+Paragraph {{item}}
+</p>
+{{/each}}
+
+</body>
+</html>


### PR DESCRIPTION
`org.apache.commons.text.TextStringBuilder` has a very poor buffer growth strategy.

It increases it by the length of the string to be appended, so *every* append causes *all* the existing data to be copied to a new location in memory.

`java.io.StringBuilder` has a much better approach of doubling the capacity of the buffer each time it is too small, resulting in far fewer copies.

Additionally, it seems to me that setting the initial capacity to double the size of the template will minimise the chances of a copy being needed at all.

On my machine `LargeHbsBench` runs c. 100 times faster, and`HbsBench` runs about 20% faster.