### PR TITLE
Ammend more consistent naming using CharSequence instead of String

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
@@ -225,12 +225,17 @@ class Variable extends HelperResolver {
    */
   protected CharSequence formatAndEscape(final Object value, final Formatter.Chain formatter) {
     Object formatted = formatter.format(value);
-    CharSequence formattedString = formatted.toString();
-    if (formatted instanceof Handlebars.SafeString) {
-        return formattedString;
+    CharSequence formattedCharSequence;
+    if (value instanceof CharSequence) {
+      formattedCharSequence = (CharSequence) value;
+    } else {
+      formattedCharSequence = formatted.toString();
     }
-    CharSequence escapedString = escapingStrategy.escape(formattedString);
-    return escapedString;
+    if (formatted instanceof Handlebars.SafeString) {
+        return formattedCharSequence;
+    }
+    CharSequence escapedCharSequence = escapingStrategy.escape(formattedCharSequence);
+    return escapedCharSequence;
   }
 
   @Override


### PR DESCRIPTION
**Background**
As part of security requirements - to avoid leaving traces of very sensitive data in memory, we are trying to clear memory as much as it is possible. All instance of **java.lang.String** are immutable and stay in memory until Garbage Collector deletes them. 

**Solution** 
Avoid needlessly calling **.toString()** if the value already is a CharSequence
