### PR TITLE
Work around the Android Java version issue

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -248,7 +248,17 @@ public class Handlebars implements HelperRegistry {
 
     static int javaVersion() {
       String version = System.getProperty("java.specification.version").trim();
-      return Integer.parseInt(version.replace(VERSION_PREFIX, ""));
+      try {
+        return Integer.parseInt(version.replace(VERSION_PREFIX, ""));
+      } catch (NumberFormatException ex) {
+        // a workaround for Android apps where the [java.specification.version] property is set to 0.9
+        // https://developer.android.com/reference/java/lang/System#getProperties()
+        if (version.equals("0.9")) {
+          return 8;
+        } else {
+          throw ex;
+        }
+      }
     }
 
     /**


### PR DESCRIPTION
Android does not use a particular Java version and because of that the property value is 0.9 which results in a NumberFormatException. As before, Android should default to 8.