### PR TITLE
Fix #1018 with automatic module name 4.x

### DIFF
--- a/handlebars-caffeine/pom.xml
+++ b/handlebars-caffeine/pom.xml
@@ -14,6 +14,10 @@
 
   <name>Handlebars Caffeine Cache</name>
 
+  <properties>
+    <module.name>handlebars.caffeine</module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/handlebars-guava-cache/pom.xml
+++ b/handlebars-guava-cache/pom.xml
@@ -14,6 +14,10 @@
 
   <name>Handlebars Guava Cache</name>
 
+  <properties>
+    <module.name>handlebars.guavacache</module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/handlebars-helpers/pom.xml
+++ b/handlebars-helpers/pom.xml
@@ -13,6 +13,10 @@
 
   <name>Handlebars Helpers</name>
   <description>A collection helpers donated by the community</description>
+  
+  <properties>
+    <module.name>handlebars.helpers</module.name>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/handlebars-humanize/pom.xml
+++ b/handlebars-humanize/pom.xml
@@ -13,6 +13,10 @@
 
   <name>Humanize helpers</name>
 
+  <properties>
+    <module.name>handlebars.humanize</module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/handlebars-jackson2/pom.xml
+++ b/handlebars-jackson2/pom.xml
@@ -14,6 +14,10 @@
   <name>A Jackson 2.x helper</name>
   <description>A JSON Helper base on Jackson2</description>
 
+  <properties>
+    <module.name>handlebars.jackson2</module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/handlebars-maven-plugin/pom.xml
+++ b/handlebars-maven-plugin/pom.xml
@@ -15,6 +15,10 @@
   <name>Handlebars.js maven plugin</name>
   <description>Compile Handlebars templates to JavaScript</description>
 
+  <properties>
+    <module.name>handlebars.maven</module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/handlebars-proto/pom.xml
+++ b/handlebars-proto/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <jetty-version>9.4.44.v20210927</jetty-version>
+    <module.name>handlebars.proto</module.name>
   </properties>
 
   <build>

--- a/handlebars-springmvc/pom.xml
+++ b/handlebars-springmvc/pom.xml
@@ -14,6 +14,10 @@
   <name>Handlebars Spring MVC</name>
   <description>Spring MVC Integration for Handlebars.java</description>
 
+  <properties>
+    <module.name>handlebars.springmvc</module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.jknack</groupId>

--- a/handlebars/pom.xml
+++ b/handlebars/pom.xml
@@ -230,6 +230,7 @@
   <properties>
     <antlr-version>4.9.3</antlr-version>
     <nashorn.version>15.3</nashorn.version>
+    <module.name>handlebars</module.name>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,13 @@
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${project.groupId}.${module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
 
       <!-- sure-fire -->


### PR DESCRIPTION
This pr is on the 4.x branch as the master branch should use proper module-info.