### PR TITLE
Remove Markdown module from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,26 +898,6 @@ Maven:
 
 Same as Jackson1.x, except for the name of the helper: ```Jackson2Helper```
 
-## Markdown
-
-Maven:
-```xml
- <dependency>
-   <groupId>com.github.jknack</groupId>
-   <artifactId>handlebars-markdown</artifactId>
-   <version>${handlebars-version}</version>
- </dependency>
-```
-Usage:
-
-```java
- handlebars.registerHelper("md", new MarkdownHelper());
-```
-```
- {{md context}}
-```
-context: An object or null. Required.
-
 ## Humanize
 
 Maven:


### PR DESCRIPTION
`handlebars-markdown` module was removed in https://github.com/jknack/handlebars.java/issues/900. This PR removed removes Markdown module from Readme. 