### PR TITLE
Add support for escaping raw expressions (TVAR)

### DIFF
--- a/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
+++ b/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
@@ -76,6 +76,11 @@ lexer grammar HbsLexer;
   }
 
   private boolean varEscape(final String start, final String end) {
+    // Support escaping raw expressions (TVar) and normal expressions (VAR)
+    return consumeVarEscape(start + "{", end + "}") || consumeVarEscape(start, end);
+  }
+
+  private boolean consumeVarEscape(final String start, final String end) {
     if (ahead("\\" + start)) {
       int offset = start.length();
       while (!isEOF(offset)) {

--- a/handlebars/src/test/java/com/github/jknack/handlebars/AbstractTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/AbstractTest.java
@@ -87,7 +87,7 @@ public class AbstractTest {
       throws IOException {
     Template t = compile(template, helpers, partials);
     String result = t.apply(configureContext(context));
-    assertEquals("'" + expected + "' should === '" + result + "': " + message, expected, result);
+    assertEquals("'" + result + "' should === '" + expected + "': " + message, expected, result);
   }
 
   protected Object configureContext(final Object context) {

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i1084/Issue1084.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i1084/Issue1084.java
@@ -1,0 +1,48 @@
+package com.github.jknack.handlebars.i1084;
+
+import com.github.jknack.handlebars.AbstractTest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue1084 extends AbstractTest {
+
+    @Test
+    public void escapeRawVars() throws IOException {
+        shouldCompileTo("\\{{{foo}}}", $, "{{{foo}}}");
+    }
+
+    @Test
+    public void escapeRawVarsWithText() throws IOException {
+        shouldCompileTo("before \\{{{foo}}} after", $, "before {{{foo}}} after");
+    }
+
+    @Test
+    public void escapeRawVsUnescape() throws IOException {
+        shouldCompileTo("\\{{{foo}}} {{{foo}}}", $("foo", "bar"), "{{{foo}}} bar");
+    }
+
+    @Test
+    public void escapeRawMultiline() throws IOException {
+        shouldCompileTo("\\{{{foo\n}}}", $("foo", "bar"), "{{{foo\n}}}");
+    }
+
+    @Test
+    public void rawBlockEscape() throws IOException {
+        shouldCompileTo("\\{{{#foo}}}", $("foo", "bar"), "{{{#foo}}}");
+    }
+
+    @Test
+    public void rawBlockEscapeWithParams() throws IOException {
+        shouldCompileTo("\\{{{#foo x a x}}}", $("foo", "bar"), "{{{#foo x a x}}}");
+    }
+
+    @Test
+    public void escapeRawVarToText() throws IOException {
+        assertEquals("\\{{{foo}}}", compile("\\{{{foo}}}").text());
+    }
+
+}
+


### PR DESCRIPTION
Fixes Issue #1084 

Escaping raw expressions (TVAR) is supported by **Handlebars.js**, but **Handlebars.java** currently only supports escaping normal expressions (VAR). It is a simple fix to also support escaping raw expressions by updating `varEscape` to first check with the extra curly bracket in the delimiters like `start + "}"` and `end + "}"`, then otherwise check with the normal start and end delimiters like before. The visitEscape function doesn't need to change since the ignoring behavior is the same, we only care to drop the escape character.

It would be great if this could be merged, and a new version cut and released as soon as possible. This is a big gap in this implementation, and we need it fixed ASAP. Much appreciated!