### PR TITLE
Add Java 21 to CI

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [17]
+        java_version: [17,21]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
I was about to write a test case for handlebars 4.4.0 with Java 21, but apparently the project doesn't compile yet with 21. Running tests locally results in 13 test failures under Java 21. Opened PR to have CI reflect that state. All failures locally are i18n related and throw `java.lang.UnsupportedOperationException` so hopefully just that one module change to fix them all.