### PR TITLE
[ISSUE-567] Fix the test of issue 567

### DIFF
--- a/handlebars/src/test/java/com/github/jknack/handlebars/issues/Issue567.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/issues/Issue567.java
@@ -15,9 +15,20 @@ public class Issue567 extends v4Test {
 
   @Test
   public void shouldKeepContextOnBlockParameter() throws Exception {
-    shouldCompileTo(
+    String[] expected = new String[] {
+      "  context is {v=a, k=0}  context is {v=b, k=1}  context is {v=c, k=2}",
+      "  context is {v=a, k=0}  context is {v=b, k=1}  context is {k=2, v=c}",
+      "  context is {v=a, k=0}  context is {k=1, v=b}  context is {v=c, k=2}",
+      "  context is {v=a, k=0}  context is {k=1, v=b}  context is {k=2, v=c}",
+      "  context is {k=0, v=a}  context is {v=b, k=1}  context is {v=c, k=2}",
+      "  context is {k=0, v=a}  context is {v=b, k=1}  context is {k=2, v=c}",
+      "  context is {k=0, v=a}  context is {k=1, v=b}  context is {v=c, k=2}",
+      "  context is {k=0, v=a}  context is {k=1, v=b}  context is {k=2, v=c}"
+    };
+  
+    hashShouldCompileTo(
         "{{#each foo as |v k|}}" + "  context is {{{.}}}" + "{{/each}}",
         $("hash", $("foo", Arrays.asList("a", "b", "c"))),
-        "  context is {v=a, k=0}  context is {v=b, k=1}  context is {v=c, k=2}");
+        expected);
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/v4Test.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/v4Test.java
@@ -6,6 +6,7 @@
 package com.github.jknack.handlebars;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -29,6 +30,17 @@ public class v4Test {
     String result = t.apply(configureContext(hash));
     assertEquals(expected, result, "'" + expected + "' should === '" + result + "': ");
   }
+
+  public void hashShouldCompileTo(final String template, final Hash data, final String[] expected)
+      throws IOException {
+    Template t = compile(template, data);
+    Object hash = data.get("hash");
+    String result = t.apply(configureContext(hash));
+    assertTrue(
+      java.util.Arrays.asList(expected).contains(result),
+      "Result '" + result + "' does not match any of the expected values: " + java.util.Arrays.toString(expected)
+    );
+}
 
   protected Object configureContext(final Object context) {
     return context;


### PR DESCRIPTION
### Issue:
Test Issue567 doesn't pass when running the test. In shouldCompileTo, I found the output string has a different order for the fields. This is because formatted.toString() in Variable class doesn't ensure order when formatted is a hashmap.
![image](https://github.com/user-attachments/assets/abe482a9-9a86-4cdb-ab47-88e8d002ff0d)
![image](https://github.com/user-attachments/assets/21ddbb4e-a2d1-4445-8810-8fb7a38e7fea)

### Change:
Add all possible out to expect, so the test will always succeed.

