### PR TITLE
Rework append for better memory efficiency

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
@@ -767,7 +767,7 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
             list.add(candidate);
             prev = candidate;
           } else {
-            ((Text) prev).append(((Text) candidate).textWithoutEscapeChar());
+            ((Text) prev).append(((Text) candidate));
           }
         } else {
           list.add(candidate);

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Text.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Text.java
@@ -20,10 +20,10 @@ import com.github.jknack.handlebars.Handlebars;
 class Text extends BaseTemplate {
 
   /** The plain text. Required. */
-  private StringBuilder text;
+  private final StringBuilder text;
 
   /** The escape's char or empty. */
-  private String escapeChar;
+  private final String escapeChar;
 
   /**
    * Creates a new {@link Text}.
@@ -53,26 +53,20 @@ class Text extends BaseTemplate {
     return escapeChar + text.toString();
   }
 
-  /**
-   * @return Same as {@link #text()} without the escape char.
-   */
-  public char[] textWithoutEscapeChar() {
-    return text.toString().toCharArray();
-  }
-
   @Override
   protected void merge(final Context scope, final Writer writer) throws IOException {
     writer.write(text.toString());
   }
 
   /**
-   * Append text.
+   * Merges the content of the given {@link Text} instance into this instance.
    *
-   * @param text The text to append.
-   * @return This object.
+   * @param other the {@link Text} instance to merge with this instance;
+   *               if null or contains no text, no action is taken
    */
-  public Text append(final char[] text) {
-    this.text.append(text);
-    return this;
+  public void append(final Text other) {
+    if (other != null && other.text != null) {
+      this.text.append(other.text);
+    }
   }
 }


### PR DESCRIPTION
Trying to optimize the append method to improve memory efficiency and reduce object allocations. Previously, the code relied on the `textWithoutEscapeChar` method, which involved converting the internal `StringBuilder` to a `String` and then to a `char[]`. My goal here is to reduce unnecessary intermediate allocations and processing overhead.

## Changes Introduced
- Streamlined operations to minimize the number of object switches and allocations during the append process.
- Removed `textWithoutEscapeChar` to avoid the conversion chain (`StringBuilder` → `String` → `char[]`).

## Alternative Consideration:
An alternative approach considered was to rewrite the `textWithoutEscapeChar` method for better performance. The revised method would look like this:

```java
public char[] textWithoutEscapeChar() {
  char[] result = new char[text.length()];
  text.getChars(0, text.length(), result, 0);
  return result;
}
```

This version avoids converting the `StringBuilder` to a `String` and directly copies the characters into a `char[]`, reducing unnecessary overhead.

## Future Enhancements:
There is a potential case to investigate the frequent resizing of the `StringBuilder` used in `Text`. Pre-sizing the `StringBuilder` to an appropriate capacity may further improve performance and memory usage.

