### PR TITLE
fix(issue-1160): support named 'locale' and 'format' parameters

### DIFF
--- a/handlebars/src/test/java/com/github/jknack/handlebars/NumberFormatTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/NumberFormatTest.java
@@ -72,11 +72,27 @@ public class NumberFormatTest extends AbstractTest {
     shouldCompileTo("{{numberFormat this \"" + pattern + "\" \"fr\"}}", number, expected);
   }
 
-  public static Date date(final int day, final int month, final int year) {
-    Calendar calendar = Calendar.getInstance();
-    calendar.set(Calendar.DATE, day);
-    calendar.set(Calendar.MONTH, month - 1);
-    calendar.set(Calendar.YEAR, year);
-    return calendar.getTime();
+  @Test
+  public void namedFormat() throws IOException {
+    final Number number = Math.PI;
+    final Locale defaultLocale = Locale.getDefault();
+    final String expected = NumberFormat
+            .getPercentInstance(defaultLocale)
+            .format(number);
+
+    shouldCompileTo("{{numberFormat this format=\"percent\"}}", number, expected);
+  }
+
+  @Test
+  public void namedBrLocale() throws IOException {
+    final Number number = Math.PI;
+    final String pattern = "currency";
+    final Locale portuguese = Locale.forLanguageTag("pt-BR");
+
+    final String expected = NumberFormat
+            .getCurrencyInstance(portuguese)
+            .format(number);
+
+    shouldCompileTo("{{numberFormat this \"" + pattern + "\" locale=\"pt-BR\"}}", number, expected);
   }
 }


### PR DESCRIPTION
Fixes #1160 

This change enhances the numberFormat helper to support both 'format' and
'locale' as named parameters (via options hash), in addition to their
existing support as positional arguments.

The implementation now follows the same flexible pattern used by the
dateFormat helper. The Javadoc has been updated accordingly.

Includes tests for:
- format as a named parameter
- locale as a named parameter
- mixed positional + named usage
- support for locale strings like 'pt-BR'