### PR TITLE
[ISSUE-1168] Read whitespace in tokenstream and reconstruct source content

### DIFF
--- a/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
+++ b/handlebars/src/main/antlr4/com/github/jknack/handlebars/internal/HbsLexer.g4
@@ -9,6 +9,8 @@ lexer grammar HbsLexer;
 
   boolean whiteSpaceControl;
 
+  public static final int WHITESPACE_CHANNEL = 1;
+
   public HbsLexer(CharStream input, String start, String end) {
     this(input);
     this.start = start;
@@ -374,5 +376,5 @@ RP
   ;
 
 WS
- : [ \t\r\n] -> skip
+ : [ \t\r\n] -> channel(1)
  ;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Template.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Template.java
@@ -135,6 +135,20 @@ public interface Template {
   String text();
 
   /**
+   * Provide the exact original source text including all whitespace. This method provides lossless
+   * source reconstruction by using whitespace preserved on hidden channels during parsing.
+   *
+   * <p>If token information is not available (for templates created without token streams), this
+   * method falls back to {@link #text()}.
+   *
+   * @return The exact original source text, or reconstructed text if token info unavailable.
+   * @since 4.6.0
+   */
+  default String getSourceText() {
+    return text();
+  }
+
+  /**
    * Convert this template to JavaScript template (a.k.a precompiled template). Compilation is done
    * by handlebars.js and a JS Engine (usually Rhino).
    *

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
 import org.apache.commons.lang3.StringUtils;
 
 import com.github.jknack.handlebars.Context;
@@ -58,6 +60,18 @@ abstract class BaseTemplate implements Template {
 
   /** A pre-compiled JavaScript function. */
   private String javaScript;
+
+  /**
+   * Token stream for lossless source reconstruction. Optional - if null, falls back to text()
+   * reconstruction.
+   */
+  protected CommonTokenStream tokenStream;
+
+  /** Start token index in the token stream (inclusive). */
+  protected int startTokenIndex = -1;
+
+  /** End token index in the token stream (inclusive). */
+  protected int endTokenIndex = -1;
 
   /**
    * Creates a new {@link BaseTemplate}.
@@ -192,6 +206,57 @@ abstract class BaseTemplate implements Template {
     this.line = line;
     this.column = column;
     return this;
+  }
+
+  /**
+   * Set the token stream for lossless source reconstruction.
+   *
+   * @param tokenStream The token stream.
+   * @return This template.
+   */
+  public BaseTemplate tokenStream(final CommonTokenStream tokenStream) {
+    this.tokenStream = tokenStream;
+    return this;
+  }
+
+  /**
+   * Set the token span (start and end indices) for lossless source reconstruction.
+   *
+   * @param startTokenIndex The start token index (inclusive).
+   * @param endTokenIndex The end token index (inclusive).
+   * @return This template.
+   */
+  public BaseTemplate tokenSpan(final int startTokenIndex, final int endTokenIndex) {
+    this.startTokenIndex = startTokenIndex;
+    this.endTokenIndex = endTokenIndex;
+    return this;
+  }
+
+  /**
+   * Get the exact original source text for this template, including all whitespace. This provides
+   * lossless source reconstruction using the whitespace preserved on channel 1.
+   *
+   * <p>If token information is not available (for templates created without token spans), this
+   * falls back to the reconstructed text() method.
+   *
+   * @return The exact original source text, or reconstructed text if token info unavailable.
+   * @since 4.6.0
+   */
+  public String getSourceText() {
+    if (tokenStream != null && startTokenIndex >= 0 && endTokenIndex >= 0) {
+      // Extract text from ALL tokens (all channels) to get exact original source
+      // This includes whitespace tokens on channel 1
+      StringBuilder text = new StringBuilder();
+      for (int i = startTokenIndex; i <= endTokenIndex; i++) {
+        Token token = tokenStream.get(i);
+        if (token != null) {
+          text.append(token.getText());
+        }
+      }
+      return text.toString();
+    }
+    // Fallback to reconstructed text if token information not available
+    return text();
   }
 
   @Override

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.Token;
 import org.apache.commons.lang3.StringUtils;
 
 import com.github.jknack.handlebars.Context;
@@ -244,16 +243,10 @@ abstract class BaseTemplate implements Template {
    */
   public String getSourceText() {
     if (tokenStream != null && startTokenIndex >= 0 && endTokenIndex >= 0) {
-      // Extract text from ALL tokens (all channels) to get exact original source
+      // Use TokenStream.getText() to get exact original source including all channels
       // This includes whitespace tokens on channel 1
-      StringBuilder text = new StringBuilder();
-      for (int i = startTokenIndex; i <= endTokenIndex; i++) {
-        Token token = tokenStream.get(i);
-        if (token != null) {
-          text.append(token.getText());
-        }
-      }
-      return text.toString();
+      return tokenStream.getText(
+          org.antlr.v4.runtime.misc.Interval.of(startTokenIndex, endTokenIndex));
     }
     // Fallback to reconstructed text if token information not available
     return text();

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/ForwardingTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/ForwardingTemplate.java
@@ -112,6 +112,11 @@ class ForwardingTemplate implements Template {
   }
 
   @Override
+  public String getSourceText() {
+    return template.getSourceText();
+  }
+
+  @Override
   public String toJavaScript() {
     return template.toJavaScript();
   }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/HbsParserFactory.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/HbsParserFactory.java
@@ -86,7 +86,7 @@ public class HbsParserFactory implements ParserFactory {
 
         /** Build the AST. */
         TemplateBuilder builder =
-            new TemplateBuilder(handlebars, source) {
+            new TemplateBuilder(handlebars, source, (CommonTokenStream) parser.getTokenStream()) {
               @Override
               protected void reportError(
                   final CommonToken offendingToken,

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
@@ -633,6 +633,20 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
   @Override
   public Template visitTemplate(final TemplateContext ctx) {
     Template template = visitBody(ctx.body());
+
+    // Set token span for lossless source reconstruction
+    if (tokenStream != null && template instanceof BaseTemplate) {
+      BaseTemplate baseTemplate = (BaseTemplate) template;
+      // Use the body's start and stop tokens for the entire template
+      Token startToken = ctx.body().start;
+      Token stopToken = ctx.body().stop;
+      if (startToken != null && stopToken != null) {
+        baseTemplate
+            .tokenStream(tokenStream)
+            .tokenSpan(startToken.getTokenIndex(), stopToken.getTokenIndex());
+      }
+    }
+
     if (!handlebars.infiniteLoops() && template instanceof BaseTemplate) {
       template = infiniteLoop(source, (BaseTemplate) template);
     }
@@ -830,6 +844,11 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
           prev = candidate;
         }
       }
+    }
+
+    // Set token span for lossless source reconstruction
+    if (tokenStream != null && ctx.start != null && ctx.stop != null) {
+      list.tokenStream(tokenStream).tokenSpan(ctx.start.getTokenIndex(), ctx.stop.getTokenIndex());
     }
 
     return list;

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
@@ -98,6 +98,9 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
   /** The template source. Required. */
   private TemplateSource source;
 
+  /** The token stream for lossless source reconstruction. Optional. */
+  private org.antlr.v4.runtime.CommonTokenStream tokenStream;
+
   /** Flag to track dead spaces and lines. */
   private Boolean hasTag;
 
@@ -122,6 +125,22 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
   TemplateBuilder(final Handlebars handlebars, final TemplateSource source) {
     this.handlebars = notNull(handlebars, "The handlebars can't be null.");
     this.source = notNull(source, "The template source is required.");
+  }
+
+  /**
+   * Creates a new {@link TemplateBuilder} with token stream for lossless source reconstruction.
+   *
+   * @param handlebars A handlebars object. required.
+   * @param source The template source. required.
+   * @param tokenStream The token stream. optional.
+   */
+  TemplateBuilder(
+      final Handlebars handlebars,
+      final TemplateSource source,
+      final org.antlr.v4.runtime.CommonTokenStream tokenStream) {
+    this.handlebars = notNull(handlebars, "The handlebars can't be null.");
+    this.source = notNull(source, "The template source is required.");
+    this.tokenStream = tokenStream;
   }
 
   @Override
@@ -342,14 +361,16 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
   public Template visitVar(final VarContext ctx) {
     hasTag(false);
     SexprContext sexpr = ctx.sexpr();
-    return newVar(
+    return newVarWithTokens(
         sexpr.QID().getSymbol(),
         TagType.VAR,
         params(sexpr.param()),
         hash(sexpr.hash()),
         ctx.start.getText(),
         ctx.stop.getText(),
-        ctx.DECORATOR() != null);
+        ctx.DECORATOR() != null,
+        ctx.start,
+        ctx.stop);
   }
 
   @Override
@@ -365,28 +386,32 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
   public Template visitTvar(final TvarContext ctx) {
     hasTag(false);
     SexprContext sexpr = ctx.sexpr();
-    return newVar(
+    return newVarWithTokens(
         sexpr.QID().getSymbol(),
         TagType.TRIPLE_VAR,
         params(sexpr.param()),
         hash(sexpr.hash()),
         ctx.start.getText(),
         ctx.stop.getText(),
-        false);
+        false,
+        ctx.start,
+        ctx.stop);
   }
 
   @Override
   public Template visitAmpvar(final AmpvarContext ctx) {
     hasTag(false);
     SexprContext sexpr = ctx.sexpr();
-    return newVar(
+    return newVarWithTokens(
         sexpr.QID().getSymbol(),
         TagType.AMP_VAR,
         params(sexpr.param()),
         hash(sexpr.hash()),
         ctx.start.getText(),
         ctx.stop.getText(),
-        false);
+        false,
+        ctx.start,
+        ctx.stop);
   }
 
   /**
@@ -473,6 +498,37 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
         .endDelimiter(endDelimiter)
         .filename(source.filename())
         .position(name.getLine(), name.getCharPositionInLine());
+    return var;
+  }
+
+  /**
+   * Build a new {@link Variable} with token span for lossless source reconstruction.
+   *
+   * @param name The var's name.
+   * @param varType The var's type.
+   * @param params The var params.
+   * @param hash The var hash.
+   * @param startDelimiter The current start delimiter.
+   * @param endDelimiter The current end delimiter.
+   * @param decorator True, for var decorators.
+   * @param startToken The start token.
+   * @param stopToken The stop token.
+   * @return A new {@link Variable}.
+   */
+  private Variable newVarWithTokens(
+      final Token name,
+      final TagType varType,
+      final List<Param> params,
+      final Map<String, Param> hash,
+      final String startDelimiter,
+      final String endDelimiter,
+      final boolean decorator,
+      final Token startToken,
+      final Token stopToken) {
+    Variable var = newVar(name, varType, params, hash, startDelimiter, endDelimiter, decorator);
+    if (tokenStream != null && startToken != null && stopToken != null) {
+      var.tokenStream(tokenStream).tokenSpan(startToken.getTokenIndex(), stopToken.getTokenIndex());
+    }
     return var;
   }
 

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateBuilder.java
@@ -287,6 +287,17 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
       Template elsebody = visitBody(elseStmtChainContext.unlessBody);
       elseblock.body(elsebody);
 
+      // Set token span for lossless source reconstruction (else if blocks)
+      if (tokenStream != null
+          && elseStmtChainContext.start != null
+          && elseStmtChainContext.stop != null) {
+        elseblock
+            .tokenStream(tokenStream)
+            .tokenSpan(
+                elseStmtChainContext.start.getTokenIndex(),
+                elseStmtChainContext.stop.getTokenIndex());
+      }
+
       String inverseLabel = elseStmtChainContext.inverseToken.getText();
       if (inverseLabel.startsWith(startDelim)) {
         inverseLabel = inverseLabel.substring(startDelim.length());
@@ -314,6 +325,12 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
       paramStack.removeLast();
     }
     level -= 1;
+
+    // Set token span for lossless source reconstruction
+    if (tokenStream != null && ctx.start != null && ctx.stop != null) {
+      block.tokenStream(tokenStream).tokenSpan(ctx.start.getTokenIndex(), ctx.stop.getTokenIndex());
+    }
+
     return block;
   }
 
@@ -354,6 +371,12 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
     }
     hasTag(true);
     level -= 1;
+
+    // Set token span for lossless source reconstruction
+    if (tokenStream != null && ctx.start != null && ctx.stop != null) {
+      block.tokenStream(tokenStream).tokenSpan(ctx.start.getTokenIndex(), ctx.stop.getTokenIndex());
+    }
+
     return block;
   }
 
@@ -718,6 +741,16 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
             .filename(source.filename())
             .position(info.token.getLine(), info.token.getCharPositionInLine());
 
+    // Set token span for lossless source reconstruction
+    if (tokenStream != null
+        && partial instanceof BaseTemplate
+        && ctx.start != null
+        && ctx.stop != null) {
+      ((BaseTemplate) partial)
+          .tokenStream(tokenStream)
+          .tokenSpan(ctx.start.getTokenIndex(), ctx.stop.getTokenIndex());
+    }
+
     return partial;
   }
 
@@ -747,6 +780,16 @@ abstract class TemplateBuilder extends HbsParserBaseVisitor<Object> {
             .indent(indent)
             .filename(source.filename())
             .position(info.token.getLine(), info.token.getCharPositionInLine());
+
+    // Set token span for lossless source reconstruction
+    if (tokenStream != null
+        && partial instanceof BaseTemplate
+        && ctx.start != null
+        && ctx.stop != null) {
+      ((BaseTemplate) partial)
+          .tokenStream(tokenStream)
+          .tokenSpan(ctx.start.getTokenIndex(), ctx.stop.getTokenIndex());
+    }
 
     return partial;
   }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateList.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/TemplateList.java
@@ -97,6 +97,15 @@ class TemplateList extends BaseTemplate implements Iterable<Template> {
   }
 
   @Override
+  public String getSourceText() {
+    StringBuilder buffer = new StringBuilder();
+    for (Template node : nodes) {
+      buffer.append(node.getSourceText());
+    }
+    return buffer.toString();
+  }
+
+  @Override
   public Iterator<Template> iterator() {
     return nodes.iterator();
   }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/SourceTextTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/SourceTextTest.java
@@ -1,0 +1,119 @@
+/*
+ * Handlebars.java: https://github.com/jknack/handlebars.java
+ * Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright (c) 2012 Edgar Espina
+ */
+package com.github.jknack.handlebars;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link Template#getSourceText()} */
+public class SourceTextTest extends AbstractTest {
+
+  @Test
+  public void testGetSourceTextPreservesWhitespace() throws IOException {
+    assertEquals("{{foo}}", compile("{{foo}}").getSourceText());
+    assertEquals("{{ foo }}", compile("{{ foo }}").getSourceText());
+    assertEquals("{{  foo  }}", compile("{{  foo  }}").getSourceText());
+
+    // text() still returns normalized form (backward compatibility)
+    assertEquals("{{foo}}", compile("{{foo}}").text());
+    assertEquals("{{foo}}", compile("{{ foo }}").text());
+    assertEquals("{{foo}}", compile("{{  foo  }}").text());
+  }
+
+  @Test
+  public void testGetSourceTextVarAmp() throws IOException {
+    assertEquals("{{&var}}", compile("{{&var}}").getSourceText());
+    assertEquals("{{& var }}", compile("{{& var }}").getSourceText());
+    assertEquals("{{&  var  }}", compile("{{&  var  }}").getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextVar3() throws IOException {
+    assertEquals("{{{var}}}", compile("{{{var}}}").getSourceText());
+    assertEquals("{{{ var }}}", compile("{{{ var }}}").getSourceText());
+    assertEquals("{{{  var  }}}", compile("{{{  var  }}}").getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextSection() throws IOException {
+    assertEquals(
+        "{{#section}}content{{/section}}",
+        compile("{{#section}}content{{/section}}").getSourceText());
+    assertEquals(
+        "{{# section }}content{{/ section }}",
+        compile("{{# section }}content{{/ section }}").getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextInvertedSection() throws IOException {
+    assertEquals(
+        "{{^section}}content{{/section}}",
+        compile("{{^section}}content{{/section}}").getSourceText());
+    assertEquals(
+        "{{^ section }}content{{/ section }}",
+        compile("{{^ section }}content{{/ section }}").getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextPartial() throws IOException {
+    assertEquals("{{>user}}", compile("{{>user}}", $(), $("user", "{{user}}")).getSourceText());
+    assertEquals("{{> user }}", compile("{{> user }}", $(), $("user", "{{user}}")).getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextPartialWithContext() throws IOException {
+    assertEquals(
+        "{{>user context}}",
+        compile("{{>user context}}", $(), $("user", "{{user}}")).getSourceText());
+    assertEquals(
+        "{{> user context }}",
+        compile("{{> user context }}", $(), $("user", "{{user}}")).getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextHelper() throws IOException {
+    assertEquals(
+        "{{with context arg0 hash=hash0}}",
+        compile("{{with context arg0 hash=hash0}}").getSourceText());
+    assertEquals(
+        "{{ with context arg0 hash=hash0 }}",
+        compile("{{ with context arg0 hash=hash0 }}").getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextBlockHelper() throws IOException {
+    assertEquals(
+        "{{#with context}}content{{/with}}",
+        compile("{{#with context}}content{{/with}}").getSourceText());
+    assertEquals(
+        "{{# with context }}content{{/ with }}",
+        compile("{{# with context }}content{{/ with }}").getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextPreservesAllWhitespaceTypes() throws IOException {
+    // Template with tabs
+    String source1 = "{{\tfoo\t}}";
+    assertEquals(source1, compile(source1).getSourceText());
+
+    // Template with multiple spaces
+    String source2 = "{{ foo }}  {{  bar  }}";
+    assertEquals(source2, compile(source2).getSourceText());
+
+    // Template with mixed whitespace
+    String source3 = "{{  \tfoo\t  }}";
+    assertEquals(source3, compile(source3).getSourceText());
+  }
+
+  @Test
+  public void testGetSourceTextWithTextContent() throws IOException {
+    String source = "Hello {{ name }}, welcome!";
+    assertEquals(source, compile(source).getSourceText());
+  }
+}

--- a/handlebars/src/test/java/com/github/jknack/handlebars/WhitespaceChannelTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/WhitespaceChannelTest.java
@@ -214,28 +214,78 @@ public class WhitespaceChannelTest {
   }
 
   /**
-   * Test getText() method behavior.
+   * Test getSourceText() method provides lossless source reconstruction.
    *
-   * <p><b>Note:</b> The grammar successfully preserves whitespace tokens on channel 1, and the
-   * getText() infrastructure is in place. However, full lossless reconstruction via getText()
-   * requires setting token span information during template construction, which may need additional
-   * work for complex templates.
+   * <p><b>Success!</b> The grammar successfully preserves whitespace tokens on channel 1, and the
+   * getSourceText() infrastructure is complete with token span tracking during template
+   * construction.
    *
-   * <p>For now, getText() falls back to text() reconstruction. The whitespace tokens ARE available
-   * in the token stream for formatters and linters to access directly.
+   * <p>getSourceText() now returns the exact original source including all whitespace, while text()
+   * continues to return normalized form for backward compatibility.
    */
   @Test
-  public void testGetTextBehavior() throws IOException {
+  public void testGetSourceTextPreservesWhitespace() throws IOException {
     Handlebars handlebars = new Handlebars();
 
     Template template1 = handlebars.compileInline("{{foo}}");
     Template template2 = handlebars.compileInline("{{ foo }}");
+    Template template3 = handlebars.compileInline("{{  foo  }}");
 
-    // Currently getText() falls back to text() - both return normalized form
+    // getSourceText() returns exact original source with whitespace preserved
     assertEquals("{{foo}}", template1.getSourceText());
-    assertEquals("{{foo}}", template2.getSourceText());
+    assertEquals("{{ foo }}", template2.getSourceText());
+    assertEquals("{{  foo  }}", template3.getSourceText());
 
-    // Note: The grammar DOES preserve whitespace on channel 1
-    // Future enhancement: Complete token span tracking during template construction
+    // text() still returns normalized form (backward compatibility)
+    assertEquals("{{foo}}", template1.text());
+    assertEquals("{{foo}}", template2.text());
+    assertEquals("{{foo}}", template3.text());
+  }
+
+  /**
+   * Test getSourceText() with complex templates including text and multiple variables.
+   *
+   * <p><b>Note:</b> Block templates (like {{#if}}) are not yet fully supported for lossless
+   * reconstruction. This is a future enhancement.
+   */
+  @Test
+  public void testGetSourceTextComplexTemplates() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    // Complex template with mixed whitespace and text
+    String source1 = "{{ foo }}  text  {{ bar }}";
+    Template template1 = handlebars.compileInline(source1);
+    assertEquals(source1, template1.getSourceText());
+
+    // Template with multiple variables
+    String source2 = "{{ name }} - {{ value }}";
+    Template template2 = handlebars.compileInline(source2);
+    assertEquals(source2, template2.getSourceText());
+
+    // Template with varying amounts of whitespace
+    String source3 = "{{foo}}{{bar}}{{ baz }}";
+    Template template3 = handlebars.compileInline(source3);
+    assertEquals(source3, template3.getSourceText());
+  }
+
+  /** Test getSourceText() preserves all whitespace types (spaces, tabs, newlines). */
+  @Test
+  public void testGetSourceTextPreservesAllWhitespaceTypes() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    // Template with tabs
+    String source1 = "{{\tfoo\t}}";
+    Template template1 = handlebars.compileInline(source1);
+    assertEquals(source1, template1.getSourceText());
+
+    // Template with newlines (though unusual inside tags)
+    String source2 = "{{ foo }}  {{  bar  }}";
+    Template template2 = handlebars.compileInline(source2);
+    assertEquals(source2, template2.getSourceText());
+
+    // Template with mixed whitespace
+    String source3 = "{{  \tfoo\t  }}";
+    Template template3 = handlebars.compileInline(source3);
+    assertEquals(source3, template3.getSourceText());
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/WhitespaceChannelTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/WhitespaceChannelTest.java
@@ -11,15 +11,11 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-/** Tests for whitespace retention */
 public class WhitespaceChannelTest {
 
   /**
-   * Test that whitespace INSIDE tags does NOT affect rendering (backward compatibility).
-   *
-   * <p>This verifies that the grammar change to {@code channel(1)} maintains 100% backward
-   * compatibility - whitespace inside tags is preserved in the token stream but ignored during
-   * rendering.
+   * Test that whitespace INSIDE tags does NOT affect rendering. The whitespace inside tags is
+   * preserved in the token stream but ignored during rendering.
    */
   @Test
   public void testRenderingIgnoresWhitespaceInsideTags() throws IOException {
@@ -49,39 +45,7 @@ public class WhitespaceChannelTest {
     assertEquals(template1, template4, "Whitespace inside tags should not affect rendering");
   }
 
-  /**
-   * Test that whitespace OUTSIDE tags (between elements) IS preserved in rendering.
-   *
-   * <p>This is handled by TEXT tokens, not WS tokens, and should work correctly.
-   */
-  @Test
-  public void testWhitespaceOutsideTagsPreserved() throws IOException {
-    Handlebars handlebars = new Handlebars();
-
-    Context context =
-        Context.newBuilder(
-                new Object() {
-                  public String getFoo() {
-                    return "A";
-                  }
-
-                  public String getBar() {
-                    return "B";
-                  }
-                })
-            .build();
-
-    // Whitespace between tags should be preserved
-    assertEquals("A  B", handlebars.compileInline("{{foo}}  {{bar}}").apply(context));
-    assertEquals("A\n  B", handlebars.compileInline("{{foo}}\n  {{bar}}").apply(context));
-    assertEquals("A\t\tB", handlebars.compileInline("{{foo}}\t\t{{bar}}").apply(context));
-  }
-
-  /**
-   * Test that templates compile successfully with various whitespace patterns.
-   *
-   * <p>This verifies that the grammar change doesn't break any parsing.
-   */
+  /** Test that templates compile successfully with various whitespace patterns. */
   @Test
   public void testVariousWhitespacePatterns() throws IOException {
     Handlebars handlebars = new Handlebars();
@@ -166,40 +130,7 @@ public class WhitespaceChannelTest {
         "yes", handlebars.compileInline("{{#  if  condition  }}yes{{/  if  }}").apply(context));
   }
 
-  /** Test that newlines and various whitespace types are handled correctly. */
-  @Test
-  public void testVariousWhitespaceTypes() throws IOException {
-    Handlebars handlebars = new Handlebars();
-
-    Context context =
-        Context.newBuilder(
-                new Object() {
-                  public String getFoo() {
-                    return "A";
-                  }
-
-                  public String getBar() {
-                    return "B";
-                  }
-
-                  public String getBaz() {
-                    return "C";
-                  }
-                })
-            .build();
-
-    // Different whitespace types outside tags
-    assertEquals(
-        "A \t B\r\nC", handlebars.compileInline("{{foo}} \t {{bar}}\r\n{{baz}}").apply(context));
-  }
-
-  /**
-   * Test text() method returns normalized representation (current behavior).
-   *
-   * <p><b>Note:</b> text() currently reconstructs from AST, losing original whitespace inside tags.
-   * This is expected current behavior. Full lossless reconstruction would require additional
-   * infrastructure to store original source spans.
-   */
+  /** Test text() method returns normalized representation which remove whitespaces. */
   @Test
   public void testTextMethodNormalizesWhitespace() throws IOException {
     Handlebars handlebars = new Handlebars();
@@ -211,81 +142,5 @@ public class WhitespaceChannelTest {
     // Both normalize to the same form
     assertEquals("{{foo}}", template1.text());
     assertEquals("{{foo}}", template2.text());
-  }
-
-  /**
-   * Test getSourceText() method provides lossless source reconstruction.
-   *
-   * <p><b>Success!</b> The grammar successfully preserves whitespace tokens on channel 1, and the
-   * getSourceText() infrastructure is complete with token span tracking during template
-   * construction.
-   *
-   * <p>getSourceText() now returns the exact original source including all whitespace, while text()
-   * continues to return normalized form for backward compatibility.
-   */
-  @Test
-  public void testGetSourceTextPreservesWhitespace() throws IOException {
-    Handlebars handlebars = new Handlebars();
-
-    Template template1 = handlebars.compileInline("{{foo}}");
-    Template template2 = handlebars.compileInline("{{ foo }}");
-    Template template3 = handlebars.compileInline("{{  foo  }}");
-
-    // getSourceText() returns exact original source with whitespace preserved
-    assertEquals("{{foo}}", template1.getSourceText());
-    assertEquals("{{ foo }}", template2.getSourceText());
-    assertEquals("{{  foo  }}", template3.getSourceText());
-
-    // text() still returns normalized form (backward compatibility)
-    assertEquals("{{foo}}", template1.text());
-    assertEquals("{{foo}}", template2.text());
-    assertEquals("{{foo}}", template3.text());
-  }
-
-  /**
-   * Test getSourceText() with complex templates including text and multiple variables.
-   *
-   * <p><b>Note:</b> Block templates (like {{#if}}) are not yet fully supported for lossless
-   * reconstruction. This is a future enhancement.
-   */
-  @Test
-  public void testGetSourceTextComplexTemplates() throws IOException {
-    Handlebars handlebars = new Handlebars();
-
-    // Complex template with mixed whitespace and text
-    String source1 = "{{ foo }}  text  {{ bar }}";
-    Template template1 = handlebars.compileInline(source1);
-    assertEquals(source1, template1.getSourceText());
-
-    // Template with multiple variables
-    String source2 = "{{ name }} - {{ value }}";
-    Template template2 = handlebars.compileInline(source2);
-    assertEquals(source2, template2.getSourceText());
-
-    // Template with varying amounts of whitespace
-    String source3 = "{{foo}}{{bar}}{{ baz }}";
-    Template template3 = handlebars.compileInline(source3);
-    assertEquals(source3, template3.getSourceText());
-  }
-
-  /** Test getSourceText() preserves all whitespace types (spaces, tabs, newlines). */
-  @Test
-  public void testGetSourceTextPreservesAllWhitespaceTypes() throws IOException {
-    Handlebars handlebars = new Handlebars();
-
-    // Template with tabs
-    String source1 = "{{\tfoo\t}}";
-    Template template1 = handlebars.compileInline(source1);
-    assertEquals(source1, template1.getSourceText());
-
-    // Template with newlines (though unusual inside tags)
-    String source2 = "{{ foo }}  {{  bar  }}";
-    Template template2 = handlebars.compileInline(source2);
-    assertEquals(source2, template2.getSourceText());
-
-    // Template with mixed whitespace
-    String source3 = "{{  \tfoo\t  }}";
-    Template template3 = handlebars.compileInline(source3);
-    assertEquals(source3, template3.getSourceText());
   }
 }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/WhitespaceChannelTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/WhitespaceChannelTest.java
@@ -1,0 +1,241 @@
+/*
+ * Handlebars.java: https://github.com/jknack/handlebars.java
+ * Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright (c) 2012 Edgar Espina
+ */
+package com.github.jknack.handlebars;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for whitespace retention */
+public class WhitespaceChannelTest {
+
+  /**
+   * Test that whitespace INSIDE tags does NOT affect rendering (backward compatibility).
+   *
+   * <p>This verifies that the grammar change to {@code channel(1)} maintains 100% backward
+   * compatibility - whitespace inside tags is preserved in the token stream but ignored during
+   * rendering.
+   */
+  @Test
+  public void testRenderingIgnoresWhitespaceInsideTags() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    Context context =
+        Context.newBuilder(
+                new Object() {
+                  public String getFoo() {
+                    return "A";
+                  }
+                })
+            .build();
+
+    // These should render identically despite different whitespace inside tags
+    String template1 = handlebars.compileInline("{{foo}}").apply(context);
+    String template2 = handlebars.compileInline("{{ foo }}").apply(context);
+    String template3 = handlebars.compileInline("{{  foo  }}").apply(context);
+    String template4 = handlebars.compileInline("{{   foo   }}").apply(context);
+
+    assertEquals("A", template1);
+    assertEquals("A", template2);
+    assertEquals("A", template3);
+    assertEquals("A", template4);
+    assertEquals(template1, template2, "Whitespace inside tags should not affect rendering");
+    assertEquals(template1, template3, "Whitespace inside tags should not affect rendering");
+    assertEquals(template1, template4, "Whitespace inside tags should not affect rendering");
+  }
+
+  /**
+   * Test that whitespace OUTSIDE tags (between elements) IS preserved in rendering.
+   *
+   * <p>This is handled by TEXT tokens, not WS tokens, and should work correctly.
+   */
+  @Test
+  public void testWhitespaceOutsideTagsPreserved() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    Context context =
+        Context.newBuilder(
+                new Object() {
+                  public String getFoo() {
+                    return "A";
+                  }
+
+                  public String getBar() {
+                    return "B";
+                  }
+                })
+            .build();
+
+    // Whitespace between tags should be preserved
+    assertEquals("A  B", handlebars.compileInline("{{foo}}  {{bar}}").apply(context));
+    assertEquals("A\n  B", handlebars.compileInline("{{foo}}\n  {{bar}}").apply(context));
+    assertEquals("A\t\tB", handlebars.compileInline("{{foo}}\t\t{{bar}}").apply(context));
+  }
+
+  /**
+   * Test that templates compile successfully with various whitespace patterns.
+   *
+   * <p>This verifies that the grammar change doesn't break any parsing.
+   */
+  @Test
+  public void testVariousWhitespacePatterns() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    String[] templates = {
+      "{{foo}}",
+      "{{ foo }}",
+      "{{  foo  }}",
+      "{{   foo   }}",
+      "{{foo}}  {{bar}}",
+      "{{ foo }}  {{ bar }}",
+      "{{#if condition}}yes{{/if}}",
+      "{{# if condition }}yes{{/ if }}",
+      "{{#each items}}{{name}}{{/each}}",
+      "{{# each items }}{{ name }}{{/ each }}",
+      "{{~foo~}}",
+    };
+
+    for (String templateSource : templates) {
+      try {
+        Template template = handlebars.compileInline(templateSource);
+        assertNotNull(template, "Template should compile: " + templateSource);
+      } catch (Exception e) {
+        fail("Template failed to compile: " + templateSource + " - " + e.getMessage());
+      }
+    }
+  }
+
+  /** Test whitespace control operators still work correctly. */
+  @Test
+  public void testWhitespaceControlOperators() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    Context context =
+        Context.newBuilder(
+                new Object() {
+                  public String getFoo() {
+                    return "A";
+                  }
+
+                  public String getBar() {
+                    return "B";
+                  }
+                })
+            .build();
+
+    // Whitespace trimming operators should work
+    assertEquals("AB", handlebars.compileInline("{{~foo~}}  {{~bar~}}").apply(context));
+    assertEquals("A  B", handlebars.compileInline("{{foo}}  {{bar}}").apply(context));
+  }
+
+  /** Test complex template with nested blocks and mixed whitespace. */
+  @Test
+  public void testComplexTemplateCompilation() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    String source = "{{# each items }}\n" + "  {{ name }}  :  {{ value }}\n" + "{{/ each }}";
+
+    // Should compile without errors
+    Template template = handlebars.compileInline(source);
+    assertNotNull(template);
+  }
+
+  /** Test that block helpers with whitespace compile and render correctly. */
+  @Test
+  public void testBlockHelpersWithWhitespace() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    Context context =
+        Context.newBuilder(
+                new Object() {
+                  public boolean getCondition() {
+                    return true;
+                  }
+                })
+            .build();
+
+    // Different whitespace patterns should all work
+    assertEquals("yes", handlebars.compileInline("{{#if condition}}yes{{/if}}").apply(context));
+    assertEquals("yes", handlebars.compileInline("{{# if condition }}yes{{/ if }}").apply(context));
+    assertEquals(
+        "yes", handlebars.compileInline("{{#  if  condition  }}yes{{/  if  }}").apply(context));
+  }
+
+  /** Test that newlines and various whitespace types are handled correctly. */
+  @Test
+  public void testVariousWhitespaceTypes() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    Context context =
+        Context.newBuilder(
+                new Object() {
+                  public String getFoo() {
+                    return "A";
+                  }
+
+                  public String getBar() {
+                    return "B";
+                  }
+
+                  public String getBaz() {
+                    return "C";
+                  }
+                })
+            .build();
+
+    // Different whitespace types outside tags
+    assertEquals(
+        "A \t B\r\nC", handlebars.compileInline("{{foo}} \t {{bar}}\r\n{{baz}}").apply(context));
+  }
+
+  /**
+   * Test text() method returns normalized representation (current behavior).
+   *
+   * <p><b>Note:</b> text() currently reconstructs from AST, losing original whitespace inside tags.
+   * This is expected current behavior. Full lossless reconstruction would require additional
+   * infrastructure to store original source spans.
+   */
+  @Test
+  public void testTextMethodNormalizesWhitespace() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    // text() returns normalized form (whitespace inside tags removed)
+    Template template1 = handlebars.compileInline("{{foo}}");
+    Template template2 = handlebars.compileInline("{{ foo }}");
+
+    // Both normalize to the same form
+    assertEquals("{{foo}}", template1.text());
+    assertEquals("{{foo}}", template2.text());
+  }
+
+  /**
+   * Test getText() method behavior.
+   *
+   * <p><b>Note:</b> The grammar successfully preserves whitespace tokens on channel 1, and the
+   * getText() infrastructure is in place. However, full lossless reconstruction via getText()
+   * requires setting token span information during template construction, which may need additional
+   * work for complex templates.
+   *
+   * <p>For now, getText() falls back to text() reconstruction. The whitespace tokens ARE available
+   * in the token stream for formatters and linters to access directly.
+   */
+  @Test
+  public void testGetTextBehavior() throws IOException {
+    Handlebars handlebars = new Handlebars();
+
+    Template template1 = handlebars.compileInline("{{foo}}");
+    Template template2 = handlebars.compileInline("{{ foo }}");
+
+    // Currently getText() falls back to text() - both return normalized form
+    assertEquals("{{foo}}", template1.getSourceText());
+    assertEquals("{{foo}}", template2.getSourceText());
+
+    // Note: The grammar DOES preserve whitespace on channel 1
+    // Future enhancement: Complete token span tracking during template construction
+  }
+}


### PR DESCRIPTION
- Read whitespace to a separate channle in tokenstream.
- Added `Template.getSourceText()` for exact source reconstruction with whitespace preservation. Enables formatters, linters, and IDE tooling.

**Implementation:**
- Whitespace tokens sent to channel 1 (not skipped) in `HbsLexer.g4`
- `BaseTemplate` stores `tokenStream` + token span (start/end indices)
- `TemplateBuilder.visitTemplate()` and `visitBody()` set token spans during parsing
- `getSourceText()` uses `TokenStream.getText(Interval)` for exact reconstruction
- `ForwardingTemplate` delegates `getSourceText()` to wrapped template

**Example:**
```java
handlebars.compileInline("{{ foo }}").text();          // "{{foo}}"   (normalized, Existing)
handlebars.compileInline("{{ foo }}").getSourceText(); // "{{ foo }}" (exact, New)
```