### PR TITLE
[ISSUE - 1167] Add support for child-first resolution

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Context.java
@@ -66,6 +66,7 @@ public class Context {
       this.parent = parent;
       this.data = parent.data;
       this.resolver = parent.resolver;
+      this.childFirstResolution = parent.childFirstResolution;
     }
 
     @Override
@@ -84,7 +85,13 @@ public class Context {
 
     @Override
     protected Context newChildContext(final Object model) {
-      return new ParentFirst(model);
+      if (childFirstResolution) {
+        // Child-first
+        return new Context(model);
+      } else {
+        // Parent-first: default behavior
+        return new ParentFirst(model);
+      }
     }
   }
 
@@ -116,7 +123,13 @@ public class Context {
 
     @Override
     protected Context newChildContext(final Object model) {
-      return new ParentFirst(model);
+      if (childFirstResolution) {
+        // Child-first
+        return new Context(model);
+      } else {
+        // Parent-first: default behavior
+        return new ParentFirst(model);
+      }
     }
   }
 
@@ -143,6 +156,7 @@ public class Context {
       this.parent = parent;
       this.data = parent.data;
       this.resolver = parent.resolver;
+      this.childFirstResolution = parent.childFirstResolution;
     }
 
     @Override
@@ -307,6 +321,17 @@ public class Context {
     }
 
     /**
+     * Set whether child context is preferred over parent context when resolving variables.
+     *
+     * @param childFirstResolution True for child-first resolution, false for parent-first.
+     * @return This builder.
+     */
+    public Builder childFirstResolution(final boolean childFirstResolution) {
+      context.childFirstResolution = childFirstResolution;
+      return this;
+    }
+
+    /**
      * Build a context stack.
      *
      * @return A new context stack.
@@ -403,6 +428,12 @@ public class Context {
 
   /** The value resolver. */
   protected ValueResolver resolver;
+
+  /**
+   * If true, child context is preferred over parent context when resolving variables. This flag
+   * controls whether BlockParam and ParentFirst create ParentFirst children.
+   */
+  protected boolean childFirstResolution;
 
   /**
    * Creates a new context.
@@ -752,6 +783,7 @@ public class Context {
     child.setResolver(this.resolver);
     child.parent = this;
     child.data = this.data;
+    child.childFirstResolution = this.childFirstResolution;
     return child;
   }
 
@@ -776,6 +808,7 @@ public class Context {
     Context ctx = Context.newContext(model);
     ctx.data = context.data;
     ctx.resolver = context.resolver;
+    ctx.childFirstResolution = context.childFirstResolution;
     return ctx;
   }
 }

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java
@@ -336,6 +336,20 @@ public class Handlebars implements HelperRegistry {
   private boolean parentScopeResolution = true;
 
   /**
+   * If true, child context fields will be preferred over parent context fields when resolving
+   * variables. This affects contexts created by helpers like {{#with}}, {{#each}}, etc.
+   *
+   * <p>When false (default), contexts use parent-first resolution where parent fields can shadow
+   * child fields. This is the behavior of handlebars.js with block parameters.
+   *
+   * <p>When true, contexts use child-first resolution where child fields are checked before parent
+   * fields. This is more intuitive for Mustache-style templates.
+   *
+   * <p>Default is: false for backward compatibility.
+   */
+  private boolean childFirstResolution = false;
+
+  /**
    * If true partial blocks will be evaluated to allow side effects by defining inline blocks within
    * the partials blocks. Attention: This feature slows down the performance severly if your
    * templates use deeply nested partial blocks. Handlebars works *much* faster if this feature is
@@ -1238,6 +1252,33 @@ public class Handlebars implements HelperRegistry {
    */
   public Handlebars parentScopeResolution(final boolean parentScopeResolution) {
     setParentScopeResolution(parentScopeResolution);
+    return this;
+  }
+
+  /**
+   * @return True if child context is preferred over parent context when resolving variables.
+   */
+  public boolean childFirstResolution() {
+    return childFirstResolution;
+  }
+
+  /**
+   * If true, child context fields will be preferred over parent context fields.
+   *
+   * @param childFirstResolution True for child-first resolution, false for parent-first.
+   */
+  public void setChildFirstResolution(final boolean childFirstResolution) {
+    this.childFirstResolution = childFirstResolution;
+  }
+
+  /**
+   * If true, child context fields will be preferred over parent context fields.
+   *
+   * @param childFirstResolution True for child-first resolution, false for parent-first.
+   * @return This handlebars object.
+   */
+  public Handlebars childFirstResolution(final boolean childFirstResolution) {
+    setChildFirstResolution(childFirstResolution);
     return this;
   }
 

--- a/handlebars/src/main/java/com/github/jknack/handlebars/Options.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/Options.java
@@ -701,7 +701,7 @@ public class Options {
     if (context != null) {
       return context;
     }
-    return Context.newContext(null);
+    return Context.newBuilder(null).childFirstResolution(handlebars.childFirstResolution()).build();
   }
 
   /**

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/BaseTemplate.java
@@ -121,11 +121,13 @@ abstract class BaseTemplate implements Template {
    * @param candidate The candidate object.
    * @return A context.
    */
-  private static Context wrap(final Object candidate) {
+  private Context wrap(final Object candidate) {
     if (candidate instanceof Context) {
       return (Context) candidate;
     }
-    return Context.newContext(candidate);
+    return Context.newBuilder(candidate)
+        .childFirstResolution(handlebars.childFirstResolution())
+        .build();
   }
 
   /**
@@ -218,7 +220,7 @@ abstract class BaseTemplate implements Template {
    * @param template The target template.
    * @return A new {@link TypeSafeTemplate}.
    */
-  private static Object newTypeSafeTemplate(final Class<?> rootType, final Template template) {
+  private Object newTypeSafeTemplate(final Class<?> rootType, final Template template) {
     return Proxy.newProxyInstance(
         rootType.getClassLoader(),
         new Class[] {rootType},
@@ -275,7 +277,11 @@ abstract class BaseTemplate implements Template {
             }
 
             if ("apply".equals(methodName)) {
-              Context context = Context.newBuilder(args[0]).combine(attributes).build();
+              Context context =
+                  Context.newBuilder(args[0])
+                      .combine(attributes)
+                      .childFirstResolution(handlebars.childFirstResolution())
+                      .build();
               attributes.clear();
               if (args.length == 2) {
                 template.apply(context, (Writer) args[1]);

--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/ForwardingTemplate.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/ForwardingTemplate.java
@@ -147,9 +147,16 @@ class ForwardingTemplate implements Template {
    * @param candidate The candidate object.
    * @return A context.
    */
-  private static Context wrap(final Object candidate) {
+  private Context wrap(final Object candidate) {
     if (candidate instanceof Context) {
       return (Context) candidate;
+    }
+    // Try to get childFirstResolution from the wrapped template if it's a BaseTemplate
+    if (template instanceof BaseTemplate) {
+      BaseTemplate baseTemplate = (BaseTemplate) template;
+      return Context.newBuilder(candidate)
+          .childFirstResolution(baseTemplate.handlebars.childFirstResolution())
+          .build();
     }
     return Context.newContext(candidate);
   }
@@ -160,9 +167,16 @@ class ForwardingTemplate implements Template {
    * @param candidate The candidate object.
    * @return A context.
    */
-  private static Context wrap(final Context candidate) {
+  private Context wrap(final Context candidate) {
     if (candidate != null) {
       return candidate;
+    }
+    // Try to get childFirstResolution from the wrapped template if it's a BaseTemplate
+    if (template instanceof BaseTemplate) {
+      BaseTemplate baseTemplate = (BaseTemplate) template;
+      return Context.newBuilder(null)
+          .childFirstResolution(baseTemplate.handlebars.childFirstResolution())
+          .build();
     }
     return Context.newContext(null);
   }

--- a/handlebars/src/test/java/com/github/jknack/handlebars/ChildFirstResolutionTest.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/ChildFirstResolutionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Handlebars.java: https://github.com/jknack/handlebars.java
+ * Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright (c) 2012 Edgar Espina
+ */
+package com.github.jknack.handlebars;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+public class ChildFirstResolutionTest extends AbstractTest {
+
+  @Override
+  protected void configure(final Handlebars handlebars) {
+    handlebars.childFirstResolution(true);
+  }
+
+  @Test
+  public void testNestedWithChildFirst() throws IOException {
+    shouldCompileTo(
+        "{{x}} {{#with a}}{{x}} {{#with b}}{{x}}{{/with}}{{/with}}",
+        $("x", "1", "a", $("x", "2", "b", $("x", "3"))),
+        "1 2 3");
+  }
+
+  @Test
+  public void testBlockParamsChildFirst() throws IOException {
+    shouldCompileTo(
+        "{{#each items as |item|}}{{name}}{{/each}}",
+        $("name", "Global", "items", new Object[] {$("name", "Item1"), $("name", "Item2")}),
+        "Item1Item2");
+  }
+
+  @Test
+  public void testNestedContextsChildFirst() throws IOException {
+    shouldCompileTo(
+        "{{#each outer}}{{#with inner}}{{field}}{{/with}}{{/each}}",
+        $(
+            "field",
+            "Root",
+            "outer",
+            new Object[] {$("field", "Outer1", "inner", $("field", "Inner1"))}),
+        "Inner1");
+  }
+
+  @Test
+  public void testMixedContexts() throws IOException {
+    shouldCompileTo(
+        "{{#with person}}{{#if active}}{{name}}{{/if}}{{/with}}",
+        $("name", "Outer", "person", $("name", "Inner", "active", true)),
+        "Inner");
+  }
+
+  @Test
+  public void testChildFirstConfiguration() {
+    Handlebars handlebars = new Handlebars();
+    assertFalse(handlebars.childFirstResolution());
+
+    handlebars.setChildFirstResolution(true);
+    assertTrue(handlebars.childFirstResolution());
+
+    Handlebars handlebars2 = new Handlebars().childFirstResolution(true);
+    assertTrue(handlebars2.childFirstResolution());
+  }
+
+  @Test
+  public void testEachWithIndexChildFirst() throws IOException {
+    shouldCompileTo(
+        "{{#each items as |item index|}}{{index}}:{{value}} {{/each}}",
+        $("value", "Global", "items", new Object[] {$("value", "A"), $("value", "B")}),
+        "0:A 1:B ");
+  }
+
+  @Test
+  public void testPartialWithChildFirst() throws IOException {
+    shouldCompileToWithPartials(
+        "{{> partial name=\"Override\"}}",
+        $("name", "Original"),
+        $("partial", "{{name}}"),
+        "Override");
+  }
+
+  @Test
+  public void testWithHelperMapData() throws IOException {
+    shouldCompileTo(
+        "Name: {{name}}\n{{#with person}}Name: {{name}}\nAge: {{age}}{{/with}}",
+        $("name", "Outer", "person", $("name", "Inner", "age", 30)),
+        "Name: Outer\nName: Inner\nAge: 30");
+  }
+
+  @Test
+  public void testEachItemsWithGlobalField() throws IOException {
+    shouldCompileTo(
+        "{{#each items}}Global: {{globalField}}\nItem: {{name}}\n{{/each}}",
+        $(
+            "globalField",
+            "Global Value",
+            "items",
+            new Object[] {
+              $("name", "Item 1", "globalField", "Item 1 Global"),
+              $("name", "Item 2", "globalField", "Item 2 Global")
+            }),
+        "Global: Item 1 Global\nItem: Item 1\nGlobal: Item 2 Global\nItem: Item 2\n");
+  }
+
+  @Test
+  public void testDeepNestingChildFirst() throws IOException {
+    shouldCompileTo(
+        "{{#with a}}{{#with b}}{{#with c}}{{value}}{{/with}}{{/with}}{{/with}}",
+        $(
+            "value",
+            "root",
+            "a",
+            $("value", "a-value", "b", $("value", "b-value", "c", $("value", "c-value")))),
+        "c-value");
+  }
+
+  @Test
+  public void testLocalPathBehavior() throws IOException {
+    shouldCompileTo(
+        "{{#with child}}{{./name}}{{/with}}",
+        $("name", "Parent", "child", $("name", "Child")),
+        "Child");
+  }
+}


### PR DESCRIPTION
Handlebars.js uses child-first resolution instead of parent-first resolution: https://handlebarsjs.com/guide/expressions.html#changing-the-context

This pr allows to define the resolution(`child-first` vs `parent-first`) in the Handlebars intilaization allowing clients to decide the resolution method. Default resolution is parent-first making it backward compatible.

Issue link: https://github.com/jknack/handlebars.java/issues/1167