### PR TITLE
[ISSUE-820] Support helpers used without arguments in a block

### DIFF
--- a/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
+++ b/handlebars/src/main/java/com/github/jknack/handlebars/internal/Variable.java
@@ -67,9 +67,6 @@ class Variable extends HelperResolver {
   /** Block params. */
   private static final List<String> BPARAMS = Collections.emptyList();
 
-  /** True, when no param/hash. */
-  private boolean noArg;
-
   /** Empty var. */
   private Template emptyVar;
 
@@ -98,7 +95,6 @@ class Variable extends HelperResolver {
     this.escapingStrategy =
         type == TagType.VAR ? handlebars.getEscapingStrategy() : EscapingStrategy.NOOP;
     this.formatter = handlebars.getFormatter();
-    this.noArg = params.size() == 0 && hash.size() == 0;
     postInit();
   }
 
@@ -135,8 +131,9 @@ class Variable extends HelperResolver {
    */
   @SuppressWarnings("unchecked")
   public Object value(final Context scope, final Writer writer) throws IOException {
-    boolean blockParam = scope.isBlockParams() && noArg;
-    if (helper != null && !blockParam) {
+    boolean blockParam = scope.isBlockParams();
+    Object value = scope.get(path);
+    if (helper != null && (!blockParam || (path.size() == 1 && value == null))) {
       Options options =
           new Options(
               handlebars,
@@ -152,7 +149,6 @@ class Variable extends HelperResolver {
       options.data(Context.PARAM_SIZE, this.params.size());
       return helper.apply(determineContext(scope), options);
     } else {
-      Object value = scope.get(path);
       if (value == null) {
         if (missing != null) {
           Options options =

--- a/handlebars/src/test/java/com/github/jknack/handlebars/i820/Issue820.java
+++ b/handlebars/src/test/java/com/github/jknack/handlebars/i820/Issue820.java
@@ -1,0 +1,28 @@
+/*
+ * Handlebars.java: https://github.com/jknack/handlebars.java
+ * Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright (c) 2012 Edgar Espina
+ */
+package com.github.jknack.handlebars.i820;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.v4Test;
+
+public class Issue820 extends v4Test {
+
+  @Override
+  protected void configure(Handlebars handlebars) {
+    handlebars.registerHelper("greeting", (context, options) -> "Hello");
+  }
+
+  /** A helper that takes no arguments should still work within a block. */
+  @Test
+  public void helperWithoutArgumentsUsedInsideEachBlock() throws Exception {
+    shouldCompileTo(
+        "{{greeting}}\n{{#each users as |user|}}{{greeting}} {{user}}\n{{/each}}",
+        $("hash", $("users", new Object[] {"Jack", "John"})),
+        "Hello\nHello Jack\nHello John\n");
+  }
+}


### PR DESCRIPTION
Support for helpers used without arguments inside a block.

This is a fix for issue #820.