### PR TITLE
Update README to clarify default value resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ In short, from a helper you can throw an Exception and Handlebars.java will add 
  Where is the ```hookContextStack``` method? Well, it depends on your application architecture.
 
 ### Using the ValueResolver
- By default, Handlebars.java use the JavaBean methods (i.e. public getXxx and isXxx methods) and Map as value resolvers.
+ By default, Handlebars.java use the JavaBean methods (i.e. public getXxx and isXxx methods), Map as value and Method as value resolvers.
  
  You can choose a different value resolver. This section describe how to do this.
  


### PR DESCRIPTION
The README doesn't list MethodValueResolver as a default resolver, but it has been added since a few years to handle java record fields.